### PR TITLE
Time range filter

### DIFF
--- a/src/components/AppPanel.jsx
+++ b/src/components/AppPanel.jsx
@@ -71,6 +71,16 @@ function AppPanel(props) {
   // TODO: Depend on chosen time window to reload as needed
 
   useEffect(() => {
+    fetch('/signalk/v1/applicationData/user/signalk-logbook/1.0')
+      .then((r) => r.json())
+      .then((v) => {
+        if (v && v.filter && v.filter.daysToShow) {
+          setDaysToShow(v.filter.daysToShow);
+        }
+      });
+  }, [loginStatus]);
+
+  useEffect(() => {
     fetch('/plugins/signalk-logbook/config')
       .then((r) => r.json())
       .then((v) => {

--- a/src/components/AppPanel.jsx
+++ b/src/components/AppPanel.jsx
@@ -53,7 +53,9 @@ function AppPanel(props) {
     fetch('/plugins/signalk-logbook/logs')
       .then((res) => res.json())
       .then((days) => {
-        const toShow = days.slice(daysToShow * -1);
+        const showFrom = new Date();
+        showFrom.setDate(showFrom.getDate() - daysToShow);
+        const toShow = days.filter((d) => d >= showFrom.toISOString().substr(0, 10));
         Promise.all(toShow.map((day) => fetch(`/plugins/signalk-logbook/logs/${day}`)
           .then((r) => r.json())))
           .then((dayEntries) => {

--- a/src/components/AppPanel.jsx
+++ b/src/components/AppPanel.jsx
@@ -27,7 +27,7 @@ function AppPanel(props) {
     entries: [],
   });
   const [activeTab, setActiveTab] = useState('timeline'); // Maybe timeline on mobile, book on desktop?
-  const [daysToShow] = useState(7);
+  const [daysToShow, setDaysToShow] = useState(7);
   const [editEntry, setEditEntry] = useState(null);
   const [viewEntry, setViewEntry] = useState(null);
   const [addEntry, setAddEntry] = useState(null);
@@ -154,6 +154,8 @@ function AppPanel(props) {
       <Metadata
         adminUI={props.adminUI}
         loginStatus={props.loginStatus}
+        daysToShow={daysToShow}
+        setDaysToShow={setDaysToShow}
         setNeedsUpdate={setNeedsUpdate}
       />
       <Row>

--- a/src/components/FilterEditor.jsx
+++ b/src/components/FilterEditor.jsx
@@ -37,7 +37,7 @@ function FilterEditor(props) {
               id="daysToShow"
               name="daysToShow"
               type="number"
-              min={0}
+              min={1}
               value={daysToShow}
               onChange={handleChange}
             />

--- a/src/components/FilterEditor.jsx
+++ b/src/components/FilterEditor.jsx
@@ -1,0 +1,59 @@
+import React, { useState } from 'react';
+import {
+  Modal,
+  ModalHeader,
+  ModalBody,
+  ModalFooter,
+  Form,
+  FormGroup,
+  Label,
+  Input,
+  Button,
+} from 'reactstrap';
+
+function FilterEditor(props) {
+  const [daysToShow, setDaysToShow] = useState(props.daysToShow);
+  function handleChange(e) {
+    const { value } = e.target;
+    setDaysToShow(parseInt(value, 10));
+  }
+  function save() {
+    props.save({
+      daysToShow,
+    });
+  }
+  return (
+    <Modal isOpen={true} toggle={props.cancel}>
+      <ModalHeader toggle={props.cancel}>
+        Filter logs by
+      </ModalHeader>
+      <ModalBody>
+        <Form>
+          <FormGroup>
+            <Label for="text">
+              How many days to show
+            </Label>
+            <Input
+              id="daysToShow"
+              name="daysToShow"
+              type="number"
+              min={0}
+              value={daysToShow}
+              onChange={handleChange}
+            />
+          </FormGroup>
+        </Form>
+      </ModalBody>
+      <ModalFooter>
+        <Button color="primary" onClick={save}>
+          Save
+        </Button>{' '}
+        <Button color="secondary" onClick={props.cancel}>
+          Cancel
+        </Button>
+      </ModalFooter>
+    </Modal>
+  );
+}
+
+export default FilterEditor;

--- a/src/components/Metadata.jsx
+++ b/src/components/Metadata.jsx
@@ -195,11 +195,14 @@ function Metadata(props) {
     </List>
     </Col>
     <Col>
-      <div
-        onClick={() => setEditFilter(true)}
-      >
-        Last {props.daysToShow} days
-      </div>
+      <List type="unstyled">
+        <ListInlineItem><b>Show</b></ListInlineItem>
+        <ListInlineItem
+          onClick={() => setEditFilter(true)}
+        >
+          Last {props.daysToShow} days
+        </ListInlineItem>
+      </List>
     </Col>
     <Col className="text-end text-right">
     <List type="unstyled">

--- a/src/components/Metadata.jsx
+++ b/src/components/Metadata.jsx
@@ -8,10 +8,12 @@ import {
 } from 'reactstrap';
 import ordinal from 'ordinal';
 import CrewEditor from './CrewEditor.jsx';
+import FilterEditor from './FilterEditor.jsx';
 import SailEditor from './SailEditor.jsx';
 
 function Metadata(props) {
   const [editSails, setEditSails] = useState(false);
+  const [editFilter, setEditFilter] = useState(false);
   const [editCrew, setEditCrew] = useState(false);
   const [crewNames, setCrew] = useState([]);
   const [sails, setSails] = useState([]);
@@ -123,6 +125,12 @@ function Metadata(props) {
         }, 1000);
       });
   }
+  function saveFilter(filter) {
+    setEditFilter(false);
+    props.setDaysToShow(filter.daysToShow);
+    // And then reload logs
+    props.setNeedsUpdate(true);
+  }
   function saveCrew(updatedCrew) {
     fetch('/signalk/v1/api/vessels/self/communication/crewNames', {
       method: 'PUT',
@@ -151,6 +159,11 @@ function Metadata(props) {
       save={saveCrew}
       username={props.loginStatus.username}
       /> : null }
+    { editFilter ? <FilterEditor
+      cancel={() => setEditFilter(false)}
+      daysToShow={props.daysToShow}
+      save={saveFilter}
+        /> : null }
     { editSails ? <SailEditor
       sails={sails}
       cancel={() => setEditSails(false)}
@@ -169,6 +182,13 @@ function Metadata(props) {
         && <Button onClick={() => setEditCrew(true)} size="sm">Edit</Button>
     }
     </List>
+    </Col>
+    <Col>
+      <div
+        onClick={() => setEditFilter(true)}
+      >
+        Last {props.daysToShow} days
+      </div>
     </Col>
     <Col className="text-end text-right">
     <List type="unstyled">

--- a/src/components/Metadata.jsx
+++ b/src/components/Metadata.jsx
@@ -126,10 +126,21 @@ function Metadata(props) {
       });
   }
   function saveFilter(filter) {
-    setEditFilter(false);
-    props.setDaysToShow(filter.daysToShow);
-    // And then reload logs
-    props.setNeedsUpdate(true);
+    fetch('/signalk/v1/applicationData/user/signalk-logbook/1.0', {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify({
+        filter,
+      }),
+    })
+      .then(() => {
+        setEditFilter(false);
+        props.setDaysToShow(filter.daysToShow);
+        // And then reload logs
+        props.setNeedsUpdate(true);
+      });
   }
   function saveCrew(updatedCrew) {
     fetch('/signalk/v1/api/vessels/self/communication/crewNames', {


### PR DESCRIPTION
Allows setting a persistent filter on how many days to show, instead of the old hardcoded seven days with entries

<img width="288" alt="Screenshot 2023-04-20 at 13 45 07" src="https://user-images.githubusercontent.com/3346/233356438-dc4edfe8-168a-4f53-88f8-b2ae3032ac52.png">


<img width="360" alt="Screenshot 2023-04-20 at 13 42 07" src="https://user-images.githubusercontent.com/3346/233355868-669ef110-d9e6-48f4-b304-34700ddf5fbd.png">

This is stored in Signal K user application data, so it should persist for the user between sessions and devices.

Refs #40 