### PR TITLE
Visually separate each calendar day in Logbook.

### DIFF
--- a/package.json
+++ b/package.json
@@ -61,6 +61,7 @@
     "@mapbox/geo-viewport": "^0.5.0",
     "circular-buffer": "^1.0.3",
     "jsonschema": "^1.4.1",
+    "luxon": "^3.3.0",
     "ordinal": "^1.0.3",
     "timezones-list": "^3.0.2",
     "where": "^0.4.1",

--- a/src/components/styles.module.css
+++ b/src/components/styles.module.css
@@ -1,0 +1,3 @@
+.new-day {
+    border-top: double 4px;
+}


### PR DESCRIPTION
Here's a UI tweak that highlights the start of a new day. 

See also #38.