### PR TITLE
Fix: automatic append wiping the day on stored-entry validation error (#58)

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "build": "webpack --mode=production",
     "lint": "eslint *.js src/ plugin/",
     "pretest": "npm run build",
-    "test": "npm run lint"
+    "test": "npm run lint && node --test"
   },
   "repository": {
     "type": "git",

--- a/plugin/Log.js
+++ b/plugin/Log.js
@@ -97,7 +97,12 @@ class Log {
         if (valid.errors.length > 0) {
           return Promise.reject(valid.errors[0]);
         }
-        return this.getDate(dateString).catch(() => []);
+        return this.getDate(dateString).catch((err) => {
+          if (err.code === 'ENOENT') {
+            return [];
+          }
+          throw err;
+        });
       })
       .then((date) => {
         const normalized = {

--- a/plugin/Log.js
+++ b/plugin/Log.js
@@ -122,7 +122,12 @@ class Log {
         if (valid.errors.length > 0) {
           return Promise.reject(valid.errors[0]);
         }
-        return this.getDate(date).catch(() => []);
+        return this.getDate(date).catch((err) => {
+          if (err.code === 'ENOENT') {
+            return [];
+          }
+          throw err;
+        });
       })
       .then((d) => {
         const normalized = {

--- a/plugin/format.js
+++ b/plugin/format.js
@@ -45,7 +45,10 @@ module.exports = function stateToEntry(state, text, author = '') {
   if (state['navigation.course.nextPoint']
     && state['navigation.course.nextPoint'].position
     && !Number.isNaN(Number(state['navigation.course.nextPoint'].position.latitude))) {
-    data.waypoint = state['navigation.course.nextPoint'].position;
+    data.waypoint = {
+      latitude: state['navigation.course.nextPoint'].position.latitude,
+      longitude: state['navigation.course.nextPoint'].position.longitude,
+    };
   }
   if (!Number.isNaN(Number(state['environment.outside.pressure']))) {
     data.barometer = parseFloat((state['environment.outside.pressure'] / 100).toFixed(2));

--- a/test/Log.test.js
+++ b/test/Log.test.js
@@ -94,3 +94,19 @@ test('appendEntry creates a new day file when none exists', async () => {
     await rm(dir, { recursive: true, force: true });
   }
 });
+
+test('writeEntry creates a new day file when none exists', async () => {
+  const dir = await mkdtemp(join(tmpdir(), 'logbook-test-'));
+  try {
+    const log = new Log(dir);
+    const entry = {
+      datetime: '2026-06-12T10:00:00.000Z', text: 'Departed', category: 'navigation',
+    };
+    await log.writeEntry(entry);
+    const after = parse(await readFile(join(dir, '2026-06-12.yml'), 'utf-8'));
+    assert.strictEqual(after.length, 1);
+    assert.strictEqual(after[0].text, 'Departed');
+  } finally {
+    await rm(dir, { recursive: true, force: true });
+  }
+});

--- a/test/Log.test.js
+++ b/test/Log.test.js
@@ -8,6 +8,40 @@ const { join } = require('node:path');
 const { stringify, parse } = require('yaml');
 const Log = require('../plugin/Log');
 
+test('writeEntry does not wipe the day when a stored entry fails validation', async () => {
+  const dir = await mkdtemp(join(tmpdir(), 'logbook-test-'));
+  try {
+    const date = '2026-06-11';
+    const stored = [
+      { datetime: '2026-06-11T08:00:00.000Z', text: 'Departed', category: 'navigation' },
+      {
+        datetime: '2026-06-11T09:00:00.000Z',
+        text: 'Sail change',
+        position: { latitude: 48.7, longitude: -123.1, foo: 'bar' },
+      },
+    ];
+    await writeFile(join(dir, `${date}.yml`), stringify(stored), 'utf-8');
+
+    const log = new Log(dir);
+    const edited = {
+      datetime: '2026-06-11T08:00:00.000Z', text: 'Departed under power', category: 'navigation',
+    };
+
+    let threw = false;
+    try {
+      await log.writeEntry(edited);
+    } catch (e) {
+      threw = true;
+    }
+
+    const after = parse(await readFile(join(dir, `${date}.yml`), 'utf-8'));
+    assert.strictEqual(after.length, 2, 'all original entries for the day must be preserved');
+    assert.ok(threw, 'writeEntry should reject when the stored day cannot be read');
+  } finally {
+    await rm(dir, { recursive: true, force: true });
+  }
+});
+
 test('appendEntry does not wipe the day when a stored entry fails validation', async () => {
   const dir = await mkdtemp(join(tmpdir(), 'logbook-test-'));
   try {

--- a/test/Log.test.js
+++ b/test/Log.test.js
@@ -1,0 +1,43 @@
+const test = require('node:test');
+const assert = require('node:assert');
+const {
+  mkdtemp, writeFile, readFile, rm,
+} = require('node:fs/promises');
+const { tmpdir } = require('node:os');
+const { join } = require('node:path');
+const { stringify, parse } = require('yaml');
+const Log = require('../plugin/Log');
+
+test('appendEntry does not wipe the day when a stored entry fails validation', async () => {
+  const dir = await mkdtemp(join(tmpdir(), 'logbook-test-'));
+  try {
+    const date = '2026-06-11';
+    const stored = [
+      { datetime: '2026-06-11T08:00:00.000Z', text: 'Departed', category: 'navigation' },
+      {
+        datetime: '2026-06-11T09:00:00.000Z',
+        text: 'Sail change',
+        position: { latitude: 48.7, longitude: -123.1, foo: 'bar' },
+      },
+    ];
+    await writeFile(join(dir, `${date}.yml`), stringify(stored), 'utf-8');
+
+    const log = new Log(dir);
+    const newEntry = {
+      datetime: '2026-06-11T10:00:00.000Z', text: 'Engine on', category: 'engine',
+    };
+
+    let threw = false;
+    try {
+      await log.appendEntry(date, newEntry);
+    } catch (e) {
+      threw = true;
+    }
+
+    const after = parse(await readFile(join(dir, `${date}.yml`), 'utf-8'));
+    assert.strictEqual(after.length, 2, 'all original entries for the day must be preserved');
+    assert.ok(threw, 'appendEntry should reject when the stored day cannot be read');
+  } finally {
+    await rm(dir, { recursive: true, force: true });
+  }
+});

--- a/test/Log.test.js
+++ b/test/Log.test.js
@@ -75,3 +75,22 @@ test('appendEntry does not wipe the day when a stored entry fails validation', a
     await rm(dir, { recursive: true, force: true });
   }
 });
+
+test('appendEntry creates a new day file when none exists', async () => {
+  const dir = await mkdtemp(join(tmpdir(), 'logbook-test-'));
+  try {
+    const log = new Log(dir);
+    const date = '2026-06-12';
+    const entry = {
+      datetime: '2026-06-12T10:00:00.000Z', text: 'Engine on', category: 'engine',
+    };
+
+    await log.appendEntry(date, entry);
+
+    const after = parse(await readFile(join(dir, `${date}.yml`), 'utf-8'));
+    assert.strictEqual(after.length, 1);
+    assert.strictEqual(after[0].text, 'Engine on');
+  } finally {
+    await rm(dir, { recursive: true, force: true });
+  }
+});

--- a/test/format.test.js
+++ b/test/format.test.js
@@ -1,0 +1,17 @@
+const test = require('node:test');
+const assert = require('node:assert');
+const stateToEntry = require('../plugin/format');
+
+test('waypoint copies only latitude and longitude', () => {
+  const state = {
+    'navigation.course.nextPoint': {
+      position: {
+        latitude: 48.7, longitude: -123.1, altitude: 0, foo: 'bar',
+      },
+    },
+  };
+
+  const entry = stateToEntry(state, 'Test entry');
+
+  assert.deepStrictEqual(entry.waypoint, { latitude: 48.7, longitude: -123.1 });
+});


### PR DESCRIPTION
Fixes #58.

Following up on the issue discussion. Two changes:

1. **`Log.js` — selective catch.** `appendEntry`/`writeEntry` did `getDate(date).catch(() => [])`. Because `getDate` re-validates the whole stored day, a single already-stored entry that no longer validates made it reject — and the catch turned that into an empty array, so the subsequent write replaced the day with just the new entry. The catch now returns `[]` only for a genuinely-absent file (`err.code === 'ENOENT'`) and re-throws otherwise, so an unreadable day is never overwritten (you lose the one automatic entry, not the day).
2. **`format.js` — waypoint pick.** Same un-picked spread the position fix (7b9fa7b) removed, but for waypoints: `data.waypoint = state['navigation.course.nextPoint'].position` copied the raw object into a field whose schema is `additionalProperties: false`. Now copies only `latitude`/`longitude`.

Added tests with the built-in `node:test` runner (no new deps; wired into `npm test`): reproductions that show the day getting wiped before the fix and preserved after, guards that new-day append/write still work, and the waypoint pick.