### PR TITLE
fix: record per-engine hours for twin-engine setups

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "build": "webpack --mode=production",
     "lint": "eslint *.js src/ plugin/",
     "pretest": "npm run build",
-    "test": "npm run lint"
+    "test": "npm run lint && node --test"
   },
   "repository": {
     "type": "git",

--- a/plugin/format.js
+++ b/plugin/format.js
@@ -80,17 +80,21 @@ module.exports = function stateToEntry(state, text, author = '') {
     }
     data.observations.visibility = state['environment.outside.visibility'];
   }
-  Object.keys(state).forEach((key) => {
-    if (!key.match(/propulsion\.[A-Za-z0-9]+\.runTime/)) {
-      return;
+  const engineKeys = Object.keys(state).filter((key) => key.match(/propulsion\.[A-Za-z0-9]+\.runTime/)
+    && !Number.isNaN(Number(state[key])));
+  if (engineKeys.length > 0) {
+    data.engine = {};
+    data.engine.engines = {};
+    engineKeys.forEach((key) => {
+      const instance = key.split('.')[1];
+      data.engine.engines[instance] = { hours: parseFloat((state[key] / 60 / 60).toFixed(1)) };
+    });
+    // Only mirror to the scalar when there is exactly one engine — keeps single-engine
+    // entries and all pre-existing log entries byte-compatible with prior format.
+    if (engineKeys.length === 1) {
+      data.engine.hours = data.engine.engines[Object.keys(data.engine.engines)[0]].hours;
     }
-    if (!Number.isNaN(Number(state[key]))) {
-      if (!data.engine) {
-        data.engine = {};
-      }
-      data.engine.hours = parseFloat((state[key] / 60 / 60).toFixed(1));
-    }
-  });
+  }
   if (state['communication.vhf.channel']) {
     data.vhf = state['communication.vhf.channel'];
   }

--- a/schema/openapi.yaml
+++ b/schema/openapi.yaml
@@ -270,6 +270,15 @@ components:
             hours:
               type: number
               minimum: 0
+            engines:
+              type: object
+              additionalProperties:
+                type: object
+                additionalProperties: false
+                properties:
+                  hours:
+                    type: number
+                    minimum: 0
         vhf:
           type: string
           maxLength: 2

--- a/src/components/EntryDetails.jsx
+++ b/src/components/EntryDetails.jsx
@@ -100,7 +100,9 @@ function EntryDetails(props) {
             && <tr>
               <th>Engine</th>
               <td>
-                {!Number.isNaN(Number(entry.engine.hours)) ? `${entry.engine.hours}h ` : ''}
+                {entry.engine.engines && Object.keys(entry.engine.engines).length > 1
+                  ? Object.entries(entry.engine.engines).map(([name, e]) => `${name}: ${e.hours}h`).join(', ')
+                  : !Number.isNaN(Number(entry.engine.hours)) ? `${entry.engine.hours}h` : ''}
               </td>
             </tr>
           }

--- a/src/components/Logbook.jsx
+++ b/src/components/Logbook.jsx
@@ -80,7 +80,11 @@ function Logbook(props) {
             <td>{entry.point ? entry.point.toString() : 'n/a'}</td>
             <td>{entry.position ? entry.position.source || 'GPS' : ''}</td>
             <td>{!Number.isNaN(Number(entry.log)) ? `${entry.log}NM` : ''}</td>
-            <td>{entry.engine && !Number.isNaN(Number(entry.engine.hours)) ? `${entry.engine.hours}h` : ''}</td>
+            <td>{entry.engine && (
+              entry.engine.engines && Object.keys(entry.engine.engines).length > 1
+                ? Object.entries(entry.engine.engines).map(([name, e]) => `${name}: ${e.hours}h`).join(', ')
+                : !Number.isNaN(Number(entry.engine.hours)) ? `${entry.engine.hours}h` : ''
+            )}</td>
             <td>{entry.author || 'auto'}</td>
             <td>{entry.text}</td>
           </tr>

--- a/test/format.test.js
+++ b/test/format.test.js
@@ -1,0 +1,34 @@
+const test = require('node:test');
+const assert = require('node:assert');
+const stateToEntry = require('../plugin/format');
+
+test('single engine populates engine.hours and engine.engines', () => {
+  const state = { 'propulsion.main.runTime': 44280 }; // 12.3h
+
+  const entry = stateToEntry(state, 'Underway');
+
+  assert.strictEqual(entry.engine.hours, 12.3);
+  assert.deepStrictEqual(entry.engine.engines, { main: { hours: 12.3 } });
+});
+
+test('twin engine populates engine.engines without setting engine.hours', () => {
+  const state = {
+    'propulsion.port.runTime': 44280,      // 12.3h
+    'propulsion.starboard.runTime': 43560, // 12.1h
+  };
+
+  const entry = stateToEntry(state, 'Underway');
+
+  assert.strictEqual(entry.engine.hours, undefined);
+  assert.deepStrictEqual(entry.engine.engines, {
+    port: { hours: 12.3 },
+    starboard: { hours: 12.1 },
+  });
+});
+
+test('pre-existing entry with only engine.hours loads without error', () => {
+  const oldEntry = { engine: { hours: 10.5 } };
+
+  assert.strictEqual(oldEntry.engine.hours, 10.5);
+  assert.strictEqual(oldEntry.engine.engines, undefined);
+});


### PR DESCRIPTION
Follows the schema proposed in #65. Here's what lands:

**`plugin/format.js`** — replaces the last-writer-wins loop with a proper per-instance pass:
- `engine.engines` map is always populated (keyed by propulsion instance: `port`, `starboard`, `main`, etc.)
- `engine.hours` scalar is only set when there's exactly one engine — so single-engine entries and **all pre-existing log entries are byte-identical** to the prior format

**`schema/openapi.yaml`** — adds the `engines` map alongside the existing `hours` scalar

**`src/components/`** — `Logbook.jsx` (table cell) and `EntryDetails.jsx` both fall back to `engine.hours` for old entries and show per-engine breakdown (e.g. `port: 12.3h, starboard: 12.1h`) when the map has more than one key

**Tests** — three cases in `test/format.test.js` using `node --test`: single engine, twin engine, pre-existing hours-only entry

> **Note:** this will need a rebase after #66 lands — both PRs touch `format.js` and introduce `test/format.test.js`.