### PR TITLE
feat: log notifications (alarms/warnings) to the logbook

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,8 +88,29 @@ The following SignalK paths are used by this logbook.
 |`propulsion.*.state`|||Propulsion changes are logged.|
 |`communication.vhf.channel`||`/vhf`||
 |`navigation.course.nextPoint.position`||`/waypoint`||
+|`notifications.*`||`/category`|Alarms and warnings are logged automatically. See below.|
 
 The [signalk-derived-data](https://github.com/sbender9/signalk-derived-data) and [signalk-path-mapper](https://github.com/sbender9/signalk-path-mapper) plugins are both useful to remap available data to the required canonical paths.
+
+## Automatic notification logging
+
+The plugin records SignalK notifications (alarms and warnings) automatically. When a
+notification rises to the configured minimum level (`warn` by default) a log entry is
+written, and another is written when it clears.
+
+To avoid log spam from a sensor that cycles across its threshold (a bilge or low-tank
+alarm, for example), repeated raises and brief clears are coalesced into a single
+*episode*: one "raised" entry when it first fires, and one "cleared" entry only after it
+has stayed clear for the debounce window — the clear entry notes how long it lasted, the
+peak level reached, and how many times it toggled.
+
+Configuration (plugin settings):
+
+* **Automatically log notifications** — master on/off (default on).
+* **Minimum notification level to log** — `alert`, `warn` (default), `alarm`, or `emergency`.
+* **Minutes a notification must stay clear before it is logged as resolved** — debounce window (default 5).
+* **Notification paths to ignore** — prefix matches to suppress known-noisy paths (e.g. `navigation.gnss`).
+* **Also log when a notification clears** — turn off for raise-only logging (default on).
 
 ## API
 

--- a/plugin/index.js
+++ b/plugin/index.js
@@ -3,6 +3,7 @@ const timezones = require('timezones-list');
 const Log = require('./Log');
 const stateToEntry = require('./format');
 const { processTriggers, processHourly } = require('./triggers');
+const { processNotification, sweepNotifications, buildConfig } = require('./notifications');
 const openAPI = require('../schema/openapi.json');
 
 const timezonesList = [
@@ -80,6 +81,7 @@ module.exports = (app) => {
     'steering.autopilot.state',
     'communication.crewNames',
     'communication.vhf.channel',
+    'notifications.*',
   ];
 
   // We keep 15min of past state to allow slight backdating of entries
@@ -87,9 +89,14 @@ module.exports = (app) => {
 
   let log;
   let state = {};
+  const episodes = new Map();
+  let notificationConfig = buildConfig({});
 
   plugin.start = () => {
     log = new Log(app.getDataDirPath());
+    const options = app.readPluginOptions();
+    notificationConfig = buildConfig((options && options.configuration) || {});
+    episodes.clear();
     const subscription = {
       context: 'vessels.self',
       subscribe: paths.map((p) => ({
@@ -115,7 +122,20 @@ module.exports = (app) => {
           return u.values.reduce((
             previousPromise,
             v,
-          ) => previousPromise.then(() => processTriggers(v.path, v.value, state, log, app)
+          ) => previousPromise.then(() => (
+            v.path.startsWith('notifications.')
+              ? processNotification(
+                v.path,
+                v.value,
+                state,
+                episodes,
+                log,
+                app,
+                notificationConfig,
+                Date.now(),
+              )
+              : processTriggers(v.path, v.value, state, log, app)
+          )
             .then((stateUpdates) => {
               if (!stateUpdates) {
                 return;
@@ -153,6 +173,10 @@ module.exports = (app) => {
         sendCrewNames(app, plugin);
       }
       buffer.enq(state);
+      sweepNotifications(episodes, state, log, app, notificationConfig, Date.now())
+        .catch((err) => {
+          app.setPluginError(`Failed to store notification entry: ${err.message}`);
+        });
       // We can keep a clone of the previous values
       state = {
         ...state,
@@ -336,6 +360,7 @@ module.exports = (app) => {
     unsubscribes.forEach((f) => f());
     unsubscribes = [];
     clearInterval(interval);
+    episodes.clear();
   };
 
   plugin.schema = {
@@ -357,6 +382,40 @@ module.exports = (app) => {
           const: tz.tzCode,
           title: tz.label,
         })),
+      },
+      logNotifications: {
+        type: 'boolean',
+        default: true,
+        title: 'Automatically log notifications (alarms and warnings)',
+      },
+      notificationMinLevel: {
+        type: 'string',
+        default: 'warn',
+        title: 'Minimum notification level to log',
+        oneOf: [
+          { const: 'alert', title: 'Alert' },
+          { const: 'warn', title: 'Warning' },
+          { const: 'alarm', title: 'Alarm' },
+          { const: 'emergency', title: 'Emergency' },
+        ],
+      },
+      notificationDebounceMinutes: {
+        type: 'number',
+        default: 5,
+        title: 'Minutes a notification must stay clear before it is logged as resolved',
+      },
+      notificationExcludePaths: {
+        type: 'array',
+        default: [],
+        title: 'Notification paths to ignore (prefix match, e.g. navigation.gnss)',
+        items: {
+          type: 'string',
+        },
+      },
+      logNotificationClears: {
+        type: 'boolean',
+        default: true,
+        title: 'Also log when a notification clears',
       },
     },
   };

--- a/plugin/notifications.js
+++ b/plugin/notifications.js
@@ -67,7 +67,8 @@ function buildConfig(options = {}) {
   return {
     enabled: options.logNotifications !== false,
     minLevel: options.notificationMinLevel || 'warn',
-    debounceMs: (Number(options.notificationDebounceMinutes) || 5) * 60000,
+    debounceMs: (options.notificationDebounceMinutes != null
+      ? Number(options.notificationDebounceMinutes) : 5) * 60000,
     excludePaths: Array.isArray(options.notificationExcludePaths)
       ? options.notificationExcludePaths : [],
     logClears: options.logNotificationClears !== false,
@@ -170,5 +171,4 @@ module.exports = {
   buildConfig,
   processNotification,
   sweepNotifications,
-  stateToEntry,
 };

--- a/plugin/notifications.js
+++ b/plugin/notifications.js
@@ -74,6 +74,67 @@ function buildConfig(options = {}) {
   };
 }
 
+function appendEntry(log, app, state, text, category, datetimeOverride) {
+  const data = stateToEntry(state, text);
+  data.category = category;
+  if (datetimeOverride) {
+    data.datetime = new Date(datetimeOverride).toISOString();
+  }
+  const dateString = new Date(data.datetime).toISOString().substr(0, 10);
+  return log.appendEntry(dateString, data)
+    .then(() => {
+      app.setPluginStatus(`Automatic log entry: ${text}`);
+      return null;
+    });
+}
+
+function processNotification(path, value, state, episodes, log, app, config, now) {
+  if (!config.enabled) {
+    return Promise.resolve();
+  }
+  const underlying = path.replace(/^notifications\./, '');
+  if (isExcluded(underlying, config.excludePaths)) {
+    return Promise.resolve();
+  }
+  const notifState = value && value.state;
+  const rank = levelRank(notifState);
+  const episode = episodes.get(path);
+
+  if (rank > 0 && rank >= levelRank(config.minLevel)) {
+    if (!episode) {
+      episodes.set(path, {
+        startTime: now,
+        openState: notifState,
+        peakState: notifState,
+        message: value && value.message,
+        transitions: 1,
+        clearedSince: null,
+      });
+      return appendEntry(
+        log,
+        app,
+        state,
+        formatRaise(value, underlying),
+        categoryForPath(underlying),
+      );
+    }
+    episode.transitions += 1;
+    episode.clearedSince = null;
+    if (value && value.message) {
+      episode.message = value.message;
+    }
+    if (LEVELS[notifState] > LEVELS[episode.peakState]) {
+      episode.peakState = notifState;
+    }
+    return Promise.resolve();
+  }
+
+  if (episode && episode.clearedSince === null) {
+    episode.clearedSince = now;
+  }
+  return Promise.resolve();
+}
+
 module.exports = {
   LEVELS,
   levelRank,
@@ -83,5 +144,6 @@ module.exports = {
   formatRaise,
   formatClear,
   buildConfig,
+  processNotification,
   stateToEntry,
 };

--- a/plugin/notifications.js
+++ b/plugin/notifications.js
@@ -138,6 +138,27 @@ function processNotification(path, value, state, episodes, log, app, config, now
   return Promise.resolve();
 }
 
+function sweepNotifications(episodes, state, log, app, config, now) {
+  const pending = [];
+  episodes.forEach((episode, path) => {
+    if (episode.clearedSince !== null && now - episode.clearedSince >= config.debounceMs) {
+      episodes.delete(path);
+      if (config.logClears) {
+        const underlying = path.replace(/^notifications\./, '');
+        pending.push(appendEntry(
+          log,
+          app,
+          state,
+          formatClear(episode, underlying),
+          categoryForPath(underlying),
+          episode.clearedSince,
+        ));
+      }
+    }
+  });
+  return Promise.all(pending);
+}
+
 module.exports = {
   LEVELS,
   levelRank,
@@ -148,5 +169,6 @@ module.exports = {
   formatClear,
   buildConfig,
   processNotification,
+  sweepNotifications,
   stateToEntry,
 };

--- a/plugin/notifications.js
+++ b/plugin/notifications.js
@@ -77,7 +77,7 @@ function buildConfig(options = {}) {
 function appendEntry(log, app, state, text, category, datetimeOverride) {
   const data = stateToEntry(state, text);
   data.category = category;
-  if (datetimeOverride) {
+  if (datetimeOverride != null) {
     data.datetime = new Date(datetimeOverride).toISOString();
   }
   const dateString = new Date(data.datetime).toISOString().substr(0, 10);
@@ -129,6 +129,9 @@ function processNotification(path, value, state, episodes, log, app, config, now
     return Promise.resolve();
   }
 
+  // A state below the configured minimum (incl. alert/normal) is intentionally
+  // treated as cleared — this also guarantees an episode that de-escalates and
+  // sticks below the threshold still closes after the debounce window.
   if (episode && episode.clearedSince === null) {
     episode.clearedSince = now;
   }

--- a/plugin/notifications.js
+++ b/plugin/notifications.js
@@ -1,0 +1,87 @@
+const stateToEntry = require('./format');
+
+// SignalK notification severity ranking. Anything unknown (incl. normal) is 0.
+const LEVELS = {
+  normal: 0,
+  alert: 1,
+  warn: 2,
+  alarm: 3,
+  emergency: 4,
+};
+
+function levelRank(state) {
+  return LEVELS[state] || 0;
+}
+
+function categoryForPath(underlying) {
+  if (/^(propulsion|electrical)\./.test(underlying)) {
+    return 'engine';
+  }
+  if (/^communication\./.test(underlying)) {
+    return 'radio';
+  }
+  return 'navigation';
+}
+
+function isExcluded(underlying, excludePaths) {
+  return excludePaths.some((prefix) => underlying === prefix
+    || underlying.startsWith(`${prefix}.`));
+}
+
+function humanDuration(ms) {
+  const totalSeconds = Math.round(ms / 1000);
+  if (totalSeconds < 60) {
+    return `${totalSeconds} s`;
+  }
+  const totalMinutes = Math.round(totalSeconds / 60);
+  if (totalMinutes < 60) {
+    return `${totalMinutes} min`;
+  }
+  const hours = Math.floor(totalMinutes / 60);
+  const minutes = totalMinutes % 60;
+  return `${hours} h ${minutes} min`;
+}
+
+function formatRaise(value, underlying) {
+  const state = (value && value.state) || 'alarm';
+  const label = state.charAt(0).toUpperCase() + state.slice(1);
+  if (value && value.message) {
+    return `${label}: ${value.message} (${underlying})`;
+  }
+  return `${label} notification: ${underlying}`;
+}
+
+function formatClear(episode, underlying) {
+  const subject = episode.message || underlying;
+  let text = `Cleared after ${humanDuration(episode.clearedSince - episode.startTime)}: ${subject}`;
+  if (LEVELS[episode.peakState] > LEVELS[episode.openState]) {
+    text += ` — peaked ${episode.peakState}`;
+  }
+  if (episode.transitions > 1) {
+    text += `, ${episode.transitions} transitions`;
+  }
+  return text;
+}
+
+function buildConfig(options = {}) {
+  return {
+    enabled: options.logNotifications !== false,
+    minLevel: options.notificationMinLevel || 'warn',
+    debounceMs: (Number(options.notificationDebounceMinutes) || 5) * 60000,
+    excludePaths: Array.isArray(options.notificationExcludePaths)
+      ? options.notificationExcludePaths : [],
+    logClears: options.logNotificationClears !== false,
+  };
+}
+
+module.exports = {
+  LEVELS,
+  levelRank,
+  categoryForPath,
+  isExcluded,
+  humanDuration,
+  formatRaise,
+  formatClear,
+  buildConfig,
+  stateToEntry,
+};

--- a/test/notifications.test.js
+++ b/test/notifications.test.js
@@ -208,3 +208,71 @@ test('excluded paths and disabled config are ignored', async () => {
   assert.strictEqual(entries.length, 0);
   assert.strictEqual(episodes.size, 0);
 });
+
+test('an episode closes only after the debounce window, logging one backdated clear', async () => {
+  const {
+    entries, log, app, state,
+  } = harness();
+  const episodes = new Map();
+  const p = 'notifications.propulsion.1.temperature';
+  const cfg = n.buildConfig({ notificationDebounceMinutes: 5 }); // 300000 ms
+  await n.processNotification(p, { state: 'alarm', message: 'High temp' }, state, episodes, log, app, cfg, 0);
+  await n.processNotification(p, { state: 'normal' }, state, episodes, log, app, cfg, 60000);
+
+  await n.sweepNotifications(episodes, state, log, app, cfg, 120000); // within window
+  assert.strictEqual(entries.length, 1);
+  assert.strictEqual(episodes.size, 1);
+
+  await n.sweepNotifications(episodes, state, log, app, cfg, 360000); // 360000 - 60000 >= 300000
+  assert.strictEqual(entries.length, 2);
+  assert.strictEqual(episodes.size, 0);
+  assert.strictEqual(entries[1].data.text, 'Cleared after 1 min: High temp');
+  assert.strictEqual(entries[1].data.datetime, new Date(60000).toISOString());
+});
+
+test('a re-raise before the window cancels the pending close', async () => {
+  const {
+    entries, log, app, state,
+  } = harness();
+  const episodes = new Map();
+  const p = 'notifications.propulsion.1.temperature';
+  const cfg = n.buildConfig({});
+  await n.processNotification(p, { state: 'alarm', message: 'Hot' }, state, episodes, log, app, cfg, 0);
+  await n.processNotification(p, { state: 'normal' }, state, episodes, log, app, cfg, 60000);
+  await n.processNotification(p, { state: 'alarm', message: 'Hot' }, state, episodes, log, app, cfg, 90000);
+  await n.sweepNotifications(episodes, state, log, app, cfg, 600000);
+  assert.strictEqual(entries.length, 1);
+  assert.strictEqual(episodes.size, 1);
+});
+
+test('a flapping notification yields exactly two entries spanning the noise', async () => {
+  const {
+    entries, log, app, state,
+  } = harness();
+  const episodes = new Map();
+  const p = 'notifications.tanks.bilge.0.level';
+  const cfg = n.buildConfig({}); // warn+, 5 min debounce
+  await n.processNotification(p, { state: 'warn', message: 'Bilge high' }, state, episodes, log, app, cfg, 0);
+  await n.processNotification(p, { state: 'normal' }, state, episodes, log, app, cfg, 1000);
+  await n.processNotification(p, { state: 'alarm', message: 'Bilge high' }, state, episodes, log, app, cfg, 2000);
+  await n.processNotification(p, { state: 'normal' }, state, episodes, log, app, cfg, 3000);
+  await n.processNotification(p, { state: 'warn', message: 'Bilge high' }, state, episodes, log, app, cfg, 4000);
+  await n.processNotification(p, { state: 'normal' }, state, episodes, log, app, cfg, 5000);
+  await n.sweepNotifications(episodes, state, log, app, cfg, 5000 + 300000);
+  assert.strictEqual(entries.length, 2);
+  assert.match(entries[1].data.text, /peaked alarm, 3 transitions/);
+});
+
+test('logNotificationClears:false closes episodes without a clear entry', async () => {
+  const {
+    entries, log, app, state,
+  } = harness();
+  const episodes = new Map();
+  const p = 'notifications.propulsion.1.temperature';
+  const cfg = n.buildConfig({ logNotificationClears: false });
+  await n.processNotification(p, { state: 'alarm', message: 'Hot' }, state, episodes, log, app, cfg, 0);
+  await n.processNotification(p, { state: 'normal' }, state, episodes, log, app, cfg, 60000);
+  await n.sweepNotifications(episodes, state, log, app, cfg, 60000 + 300000);
+  assert.strictEqual(entries.length, 1);
+  assert.strictEqual(episodes.size, 0);
+});

--- a/test/notifications.test.js
+++ b/test/notifications.test.js
@@ -84,6 +84,7 @@ test('buildConfig applies defaults and reads overrides', () => {
     excludePaths: ['navigation.gnss'],
     logClears: false,
   });
+  assert.strictEqual(n.buildConfig({ notificationDebounceMinutes: 0 }).debounceMs, 0);
 });
 
 function harness() {

--- a/test/notifications.test.js
+++ b/test/notifications.test.js
@@ -85,3 +85,126 @@ test('buildConfig applies defaults and reads overrides', () => {
     logClears: false,
   });
 });
+
+function harness() {
+  const entries = [];
+  const log = {
+    appendEntry: (date, data) => {
+      entries.push({ date, data });
+      return Promise.resolve();
+    },
+  };
+  const app = { setPluginStatus: () => {}, setPluginError: () => {} };
+  const state = { 'navigation.datetime': '2026-06-14T12:00:00.000Z' };
+  return {
+    entries, log, app, state,
+  };
+}
+
+test('a raise opens an episode and logs exactly one entry', async () => {
+  const {
+    entries, log, app, state,
+  } = harness();
+  const episodes = new Map();
+  await n.processNotification(
+    'notifications.propulsion.1.temperature',
+    { state: 'alarm', message: 'High temperature' },
+    state,
+    episodes,
+    log,
+    app,
+    n.buildConfig({}),
+    1000,
+  );
+  assert.strictEqual(entries.length, 1);
+  assert.strictEqual(entries[0].data.text, 'Alarm: High temperature (propulsion.1.temperature)');
+  assert.strictEqual(entries[0].data.category, 'engine');
+  assert.strictEqual(episodes.size, 1);
+});
+
+test('re-raises and brief clears within an episode add no further entries', async () => {
+  const {
+    entries, log, app, state,
+  } = harness();
+  const episodes = new Map();
+  const p = 'notifications.tanks.fuel.0.currentLevel';
+  const cfg = n.buildConfig({});
+  await n.processNotification(p, { state: 'warn', message: 'Low fuel' }, state, episodes, log, app, cfg, 0);
+  await n.processNotification(p, { state: 'normal' }, state, episodes, log, app, cfg, 1000);
+  await n.processNotification(
+    p,
+    { state: 'alarm', message: 'Low fuel' },
+    state,
+    episodes,
+    log,
+    app,
+    cfg,
+    2000,
+  );
+  assert.strictEqual(entries.length, 1);
+  const ep = episodes.get(p);
+  assert.strictEqual(ep.peakState, 'alarm');
+  assert.strictEqual(ep.transitions, 2);
+  assert.strictEqual(ep.clearedSince, null);
+});
+
+test('a notification below the minimum level opens nothing', async () => {
+  const {
+    entries, log, app, state,
+  } = harness();
+  const episodes = new Map();
+  await n.processNotification(
+    'notifications.x.y',
+    { state: 'warn', message: 'm' },
+    state,
+    episodes,
+    log,
+    app,
+    n.buildConfig({ notificationMinLevel: 'alarm' }),
+    0,
+  );
+  assert.strictEqual(entries.length, 0);
+  assert.strictEqual(episodes.size, 0);
+});
+
+test('a clear marks clearedSince without logging', async () => {
+  const {
+    entries, log, app, state,
+  } = harness();
+  const episodes = new Map();
+  const p = 'notifications.propulsion.1.temperature';
+  const cfg = n.buildConfig({});
+  await n.processNotification(p, { state: 'alarm', message: 'Hot' }, state, episodes, log, app, cfg, 0);
+  await n.processNotification(p, null, state, episodes, log, app, cfg, 5000);
+  assert.strictEqual(entries.length, 1);
+  assert.strictEqual(episodes.get(p).clearedSince, 5000);
+});
+
+test('excluded paths and disabled config are ignored', async () => {
+  const {
+    entries, log, app, state,
+  } = harness();
+  const episodes = new Map();
+  await n.processNotification(
+    'notifications.navigation.gnss.methodQuality',
+    { state: 'warn', message: 'm' },
+    state,
+    episodes,
+    log,
+    app,
+    n.buildConfig({ notificationExcludePaths: ['navigation.gnss'] }),
+    0,
+  );
+  await n.processNotification(
+    'notifications.propulsion.1.temperature',
+    { state: 'alarm', message: 'm' },
+    state,
+    episodes,
+    log,
+    app,
+    n.buildConfig({ logNotifications: false }),
+    0,
+  );
+  assert.strictEqual(entries.length, 0);
+  assert.strictEqual(episodes.size, 0);
+});

--- a/test/notifications.test.js
+++ b/test/notifications.test.js
@@ -1,0 +1,87 @@
+const test = require('node:test');
+const assert = require('node:assert');
+const n = require('../plugin/notifications');
+
+test('levelRank orders notification states; unknown/normal is 0', () => {
+  assert.strictEqual(n.levelRank('normal'), 0);
+  assert.strictEqual(n.levelRank('warn'), 2);
+  assert.strictEqual(n.levelRank('emergency'), 4);
+  assert.strictEqual(n.levelRank(undefined), 0);
+});
+
+test('categoryForPath maps known prefixes, defaults to navigation', () => {
+  assert.strictEqual(n.categoryForPath('propulsion.1.temperature'), 'engine');
+  assert.strictEqual(n.categoryForPath('electrical.batteries.0.voltage'), 'engine');
+  assert.strictEqual(n.categoryForPath('communication.vhf'), 'radio');
+  assert.strictEqual(n.categoryForPath('environment.wind.speedTrue'), 'navigation');
+});
+
+test('isExcluded matches an exact path or a prefix segment', () => {
+  assert.strictEqual(n.isExcluded('navigation.gnss.methodQuality', ['navigation.gnss']), true);
+  assert.strictEqual(n.isExcluded('navigation.gnss', ['navigation.gnss']), true);
+  assert.strictEqual(n.isExcluded('navigation.gnssX', ['navigation.gnss']), false);
+  assert.strictEqual(n.isExcluded('propulsion.1.temperature', []), false);
+});
+
+test('humanDuration renders seconds, minutes, and hours', () => {
+  assert.strictEqual(n.humanDuration(45000), '45 s');
+  assert.strictEqual(n.humanDuration(60000), '1 min');
+  assert.strictEqual(n.humanDuration(14 * 60000), '14 min');
+  assert.strictEqual(n.humanDuration(3 * 3600000 + 5 * 60000), '3 h 5 min');
+});
+
+test('formatRaise uses the message, or falls back to the path', () => {
+  assert.strictEqual(
+    n.formatRaise({ state: 'alarm', message: 'High temperature' }, 'propulsion.1.temperature'),
+    'Alarm: High temperature (propulsion.1.temperature)',
+  );
+  assert.strictEqual(
+    n.formatRaise({ state: 'warn' }, 'tanks.fuel.0.currentLevel'),
+    'Warn notification: tanks.fuel.0.currentLevel',
+  );
+});
+
+test('formatClear reports duration, and peak/transitions only when relevant', () => {
+  const simple = n.formatClear({
+    startTime: 0,
+    clearedSince: 60000,
+    openState: 'alarm',
+    peakState: 'alarm',
+    message: 'High temperature',
+    transitions: 1,
+  }, 'propulsion.1.temperature');
+  assert.strictEqual(simple, 'Cleared after 1 min: High temperature');
+
+  const noisy = n.formatClear({
+    startTime: 0,
+    clearedSince: 14 * 60000,
+    openState: 'warn',
+    peakState: 'alarm',
+    message: 'Low fuel',
+    transitions: 9,
+  }, 'tanks.fuel.0.currentLevel');
+  assert.strictEqual(noisy, 'Cleared after 14 min: Low fuel — peaked alarm, 9 transitions');
+});
+
+test('buildConfig applies defaults and reads overrides', () => {
+  assert.deepStrictEqual(n.buildConfig({}), {
+    enabled: true,
+    minLevel: 'warn',
+    debounceMs: 300000,
+    excludePaths: [],
+    logClears: true,
+  });
+  assert.deepStrictEqual(n.buildConfig({
+    logNotifications: false,
+    notificationMinLevel: 'alarm',
+    notificationDebounceMinutes: 2,
+    notificationExcludePaths: ['navigation.gnss'],
+    logNotificationClears: false,
+  }), {
+    enabled: false,
+    minLevel: 'alarm',
+    debounceMs: 120000,
+    excludePaths: ['navigation.gnss'],
+    logClears: false,
+  });
+});


### PR DESCRIPTION
Closes #62.

Automatically writes a log entry when a SignalK notification rises to a configurable level, and again when it clears.

## Behaviour

- Watches all `notifications.*` paths. A notification is logged once it reaches the configured minimum level (`warn` by default), and again when it returns to normal.
- **Episode coalescing / de-duplication** — the de-dup #62 calls out. A sensor that cycles across its threshold (your bilge / low-tank example) is collapsed into a single *episode*: one "raised" entry when it first fires, and one "cleared" entry only after it has stayed clear for a debounce window. The clear entry notes how long it lasted, the peak level reached, and how many times it toggled. A clean one-shot alarm produces two entries; a flapping sensor still produces only two, spanning the whole noisy period.
- Entries are categorised onto the existing category enum via a path prefix (`propulsion`/`electrical` → `engine`, `communication` → `radio`, otherwise `navigation`) — no schema change — and enriched with position/time like the other automatic entries.

## Configuration (plugin settings)

- **Automatically log notifications** (default on)
- **Minimum notification level to log** — `alert` / `warn` (default) / `alarm` / `emergency`
- **Minutes a notification must stay clear before it is logged as resolved** (default 5)
- **Notification paths to ignore** — prefix match, e.g. `navigation.gnss`
- **Also log when a notification clears** (default on)

## Implementation

- New `plugin/notifications.js` holds the level ranking, per-path episode state, entry formatting, and the raise/clear logging (`processNotification` per delta; `sweepNotifications` on the existing 60-second interval).
- `plugin/index.js` is wiring only: subscribe `notifications.*`, route those deltas, sweep on the interval, read the config, and reset episode state on stop.
- `triggers.js` is untouched.

## Test plan

- [x] `test/notifications.test.js` — 16 unit tests: raise, coalescing, debounce close, backdated clears, re-raise cancellation, flapping, min-level gating, exclude list, raise-only mode
- [x] `npm test` (build + lint + 24 tests) green
- [x] `npm run lint` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)