### PR TITLE
Default POST /logs `ago` to 0 instead of 500ing when it's omitted

### DIFF
--- a/plugin/ago.js
+++ b/plugin/ago.js
@@ -1,0 +1,16 @@
+/**
+ * Resolve the POST /logs `ago` field — how many samples back in the state
+ * buffer to snapshot — to a non-negative integer index, defaulting to 0 (the
+ * most recent sample) when the field is missing or not a finite number.
+ *
+ * Without this, a request body with no `ago` reaches `buffer.get(undefined)`,
+ * which throws `TypeError: Invalid start` and 500s the request once the state
+ * buffer has filled.
+ */
+module.exports = function resolveAgo(rawAgo) {
+  const n = Number(rawAgo);
+  if (!Number.isFinite(n) || n < 0) {
+    return 0;
+  }
+  return Math.floor(n);
+};

--- a/plugin/index.js
+++ b/plugin/index.js
@@ -3,6 +3,7 @@ const timezones = require('timezones-list');
 const Log = require('./Log');
 const stateToEntry = require('./format');
 const applyBodyFields = require('./entryFields');
+const resolveAgo = require('./ago');
 const { processTriggers, processHourly } = require('./triggers');
 const { processNotification, sweepNotifications, buildConfig } = require('./notifications');
 const openAPI = require('../schema/openapi.json');
@@ -257,13 +258,16 @@ module.exports = (app) => {
     router.post('/logs', (req, res) => {
       res.contentType('application/json');
       let stats;
-      if (req.body.ago > buffer.size()) {
+      // Default to 0 (most recent sample) when `ago` is missing/invalid —
+      // otherwise buffer.get(undefined) throws and 500s the request.
+      const ago = resolveAgo(req.body.ago);
+      if (ago > buffer.size()) {
         // We don't have history that far, sadly
         res.sendStatus(404);
         return;
       }
       if (buffer.size() > 0) {
-        stats = buffer.get(req.body.ago);
+        stats = buffer.get(ago);
       } else {
         stats = {
           ...state,

--- a/test/ago.test.js
+++ b/test/ago.test.js
@@ -1,0 +1,26 @@
+const test = require('node:test');
+const assert = require('node:assert');
+const resolveAgo = require('../plugin/ago');
+
+test('missing ago defaults to 0 (regression: buffer.get(undefined) 500d the request)', () => {
+  assert.strictEqual(resolveAgo(undefined), 0);
+});
+
+test('a valid ago is preserved', () => {
+  assert.strictEqual(resolveAgo(0), 0);
+  assert.strictEqual(resolveAgo(3), 3);
+});
+
+test('numeric strings are coerced', () => {
+  assert.strictEqual(resolveAgo('2'), 2);
+});
+
+test('negative, NaN, null and non-numeric fall back to 0', () => {
+  assert.strictEqual(resolveAgo(-1), 0);
+  assert.strictEqual(resolveAgo('abc'), 0);
+  assert.strictEqual(resolveAgo(null), 0);
+});
+
+test('fractional ago floors to an integer buffer index', () => {
+  assert.strictEqual(resolveAgo(2.9), 2);
+});


### PR DESCRIPTION
**Problem**

`POST /logs` returns a 500 when the request body has no `ago`, once the state buffer has filled:

```
TypeError: Invalid start
    at CircularBuffer.get (circular-buffer/index.js:54)
    at .../signalk-logbook/plugin/index.js:266
```

The handler calls `buffer.get(req.body.ago)`. With `ago` undefined, the range check `req.body.ago > buffer.size()` is `undefined > 16` → `false` (so the 404 guard is skipped), and `buffer.get(undefined)` throws. `ago` is optional, so a body of just `{ "text": "..." }` — or any client that doesn't send it — shouldn't crash the server.

**Fix**

A small `resolveAgo` helper (in the spirit of `entryFields.js`) that coerces `ago` to a non-negative integer and defaults to `0` (the most recent sample) when missing or invalid. Used for both the range check and `buffer.get`.

**Tested**

`test/ago.test.js` covers missing / valid / numeric-string / negative / NaN / fractional. Full suite green via `npm test`.