### PR TITLE
Fix hourly log duplicate detection

### DIFF
--- a/plugin/triggers.js
+++ b/plugin/triggers.js
@@ -240,7 +240,7 @@ exports.processHourly = function processHourly(oldState, log, app, minutesAfter 
         return Promise.resolve(true);
       }
       const withinWindow = entries.find((entry) => {
-        const diff = Math.abs(data.datetime - entry.date) / 1000 / 60;
+        const diff = Math.abs(new Date(data.datetime) - new Date(entry.datetime)) / 1000 / 60;
         if (diff < minutesAfter) {
           return true;
         }

--- a/test/triggers-hourly.test.js
+++ b/test/triggers-hourly.test.js
@@ -1,0 +1,63 @@
+const test = require('node:test');
+const assert = require('node:assert');
+const { processHourly } = require('../plugin/triggers');
+
+function appHarness() {
+  const statuses = [];
+  return {
+    statuses,
+    app: {
+      setPluginStatus: (status) => statuses.push(status),
+    },
+  };
+}
+
+test('processHourly skips when an entry already exists inside the hourly window', async () => {
+  const entries = [
+    {
+      datetime: new Date('2026-07-05T12:00:30.000Z'),
+      text: 'Manual entry',
+    },
+  ];
+  let appended = false;
+  const log = {
+    getDate: async () => entries,
+    appendEntry: async () => {
+      appended = true;
+    },
+  };
+  const { app, statuses } = appHarness();
+
+  await processHourly({
+    'navigation.state': 'sailing',
+    'navigation.datetime': '2026-07-05T12:01:00.000Z',
+  }, log, app, 1);
+
+  assert.strictEqual(appended, false);
+  assert.deepStrictEqual(statuses, ['Skipped automatic hourly log entry an entry exists already']);
+});
+
+test('processHourly writes when existing entries are outside the hourly window', async () => {
+  const entries = [
+    {
+      datetime: new Date('2026-07-05T11:58:30.000Z'),
+      text: 'Older entry',
+    },
+  ];
+  const appended = [];
+  const log = {
+    getDate: async () => entries,
+    appendEntry: async (date, entry) => {
+      appended.push({ date, entry });
+    },
+  };
+  const { app } = appHarness();
+
+  await processHourly({
+    'navigation.state': 'sailing',
+    'navigation.datetime': '2026-07-05T12:01:00.000Z',
+  }, log, app, 1);
+
+  assert.strictEqual(appended.length, 1);
+  assert.strictEqual(appended[0].date, '2026-07-05');
+});


### PR DESCRIPTION
## Summary

Fix automatic hourly log entry de-duplication so an existing entry inside the configured hourly window prevents another automatic entry from being appended.

## Root cause

`processHourly` compared `data.datetime` with `entry.date`. Existing log entries expose their timestamp as `entry.datetime`, so the comparison produced an invalid difference and failed to detect entries already inside the window.

## Impact

This prevents duplicate automatic hourly entries when a manual or automatic entry already exists close to the hourly sample time.

## Validation

- Added regression coverage for skipping entries inside the hourly window.
- Added coverage confirming entries outside the window still allow the hourly entry.
- Ran `npm test`.
