### PR TITLE
Fix crew change comparison

### DIFF
--- a/plugin/triggers.js
+++ b/plugin/triggers.js
@@ -130,7 +130,7 @@ exports.processTriggers = function processTriggers(path, value, oldState, log, a
       if (!value || !value.length) {
         return Promise.resolve();
       }
-      if (JSON.stringify(oldState[path]) === JSON.stringify(path)) {
+      if (JSON.stringify(oldState[path]) === JSON.stringify(value)) {
         return Promise.resolve();
       }
       const added = value.filter((v) => oldState[path].indexOf(v) === -1);

--- a/test/triggers-crew.test.js
+++ b/test/triggers-crew.test.js
@@ -1,0 +1,54 @@
+const test = require('node:test');
+const assert = require('node:assert');
+const { processTriggers } = require('../plugin/triggers');
+
+function appHarness() {
+  return {
+    setPluginStatus: () => {},
+  };
+}
+
+test('processTriggers ignores unchanged crew lists', async () => {
+  let appended = false;
+  const log = {
+    appendEntry: async () => {
+      appended = true;
+    },
+  };
+
+  await processTriggers(
+    'communication.crewNames',
+    ['Alice', 'Bob'],
+    {
+      'navigation.datetime': '2026-07-05T12:00:00.000Z',
+      'communication.crewNames': ['Alice', 'Bob'],
+    },
+    log,
+    appHarness(),
+  );
+
+  assert.strictEqual(appended, false);
+});
+
+test('processTriggers logs added crew member', async () => {
+  const appended = [];
+  const log = {
+    appendEntry: async (date, entry) => {
+      appended.push({ date, entry });
+    },
+  };
+
+  await processTriggers(
+    'communication.crewNames',
+    ['Alice', 'Bob'],
+    {
+      'navigation.datetime': '2026-07-05T12:00:00.000Z',
+      'communication.crewNames': ['Alice'],
+    },
+    log,
+    appHarness(),
+  );
+
+  assert.strictEqual(appended.length, 1);
+  assert.strictEqual(appended[0].entry.text, 'Bob joined the crew');
+});


### PR DESCRIPTION
## Summary

Fix crew change trigger de-duplication by comparing the previous crew list with the incoming value.

## Root cause

The unchanged-list guard compared `oldState[path]` against the path string instead of the new `value`, so unchanged crew lists were not recognized correctly.

## Impact

This prevents unnecessary crew-change log entries when the crew list is republished without an actual change.

## Validation

- Added regression coverage for unchanged crew lists.
- Added coverage confirming an added crew member still creates a log entry.
- Ran `npm test`.
