### PR TITLE
Fix ago selector value

### DIFF
--- a/src/components/EntryEditor.jsx
+++ b/src/components/EntryEditor.jsx
@@ -150,7 +150,7 @@ function EntryEditor(props) {
               id="ago"
               name="ago"
               type="select"
-              value={entry.text}
+              value={entry.ago}
               onChange={handleChange}
             >
               {agoOptions.map((ago) => (


### PR DESCRIPTION
## Summary

Fix the Add entry editor so the `ago` select is controlled by `entry.ago`.

## Root cause

The select used `entry.text` as its controlled value, so the selected snapshot offset could be disconnected from the `ago` field that is sent when creating a manual entry.

## Impact

Manual entries using a previous snapshot can now keep the selected offset consistently in the UI state.

## Validation

- Ran `npm test`, including production build and lint.
