### PR TITLE
Fix watch current metadata path

### DIFF
--- a/src/components/Metadata.jsx
+++ b/src/components/Metadata.jsx
@@ -42,7 +42,7 @@ function Metadata(props) {
           }
           return;
         }
-        if (v.patch === 'watch.current') {
+        if (v.path === 'watch.current') {
           if (onWatch !== v.value) {
             setOnWatch(v.value);
           }


### PR DESCRIPTION
## Summary

Fix watch metadata updates by checking the Signal K delta value `path` field.

## Root cause

`Metadata` checked `v.patch === 'watch.current'`, but Signal K delta values expose the field as `path`. This prevented `watch.current` updates from being handled by the metadata component.

## Impact

The currently-on-watch metadata can update when `watch.current` deltas are received.

## Validation

- Ran `npm test`, including production build and lint.
