### PR TITLE
Handle object watch current values

### DIFF
--- a/plugin/triggers.js
+++ b/plugin/triggers.js
@@ -11,6 +11,19 @@ function isUnderWay(state) {
   return false;
 }
 
+function watchLabel(value) {
+  if (!value) {
+    return '';
+  }
+  if (typeof value === 'string') {
+    return value;
+  }
+  if (typeof value !== 'object') {
+    return '';
+  }
+  return value.teamName || value.name || value.label || '';
+}
+
 function sailsString(state, app) {
   const string = [];
   Object.keys(state).forEach((path) => {
@@ -147,12 +160,14 @@ exports.processTriggers = function processTriggers(path, value, oldState, log, a
       break;
     }
     case 'watch.current': {
-      if (oldState[path] === value) {
+      const oldWatch = watchLabel(oldState[path]);
+      const newWatch = watchLabel(value);
+      if (oldWatch === newWatch) {
         // We can ignore state when it doesn't change
         return Promise.resolve();
       }
-      if (!value) {
-        if (!oldState[path]) {
+      if (!newWatch) {
+        if (!oldWatch) {
           // Falsy to falsy transition, ignore
           return Promise.resolve();
         }
@@ -164,7 +179,7 @@ exports.processTriggers = function processTriggers(path, value, oldState, log, a
         // Not under way, no need to log watches stopping
         return Promise.resolve();
       }
-      return appendLog(`${value} on watch`);
+      return appendLog(`${newWatch} on watch`);
     }
     default: {
       break;
@@ -215,6 +230,8 @@ exports.processTriggers = function processTriggers(path, value, oldState, log, a
 
   return Promise.resolve();
 };
+
+exports.watchLabel = watchLabel;
 
 exports.processHourly = function processHourly(oldState, log, app, minutesAfter = 0) {
   if (oldState['navigation.state'] !== 'sailing' && oldState['navigation.state'] !== 'motoring') {

--- a/test/triggers-watch.test.js
+++ b/test/triggers-watch.test.js
@@ -1,0 +1,63 @@
+const test = require('node:test');
+const assert = require('node:assert');
+const { processTriggers, watchLabel } = require('../plugin/triggers');
+
+function appHarness() {
+  return {
+    setPluginStatus: () => {},
+  };
+}
+
+test('watchLabel extracts a stable readable name from watch.current values', () => {
+  assert.strictEqual(watchLabel('JL'), 'JL');
+  assert.strictEqual(watchLabel({ teamName: 'JL', startTime: 1, endTime: 2 }), 'JL');
+  assert.strictEqual(watchLabel({ name: 'Port watch' }), 'Port watch');
+  assert.strictEqual(watchLabel({ label: 'Graveyard Shift' }), 'Graveyard Shift');
+  assert.strictEqual(watchLabel(null), '');
+});
+
+test('processTriggers logs object watch.current with the team name', async () => {
+  const appended = [];
+  const log = {
+    appendEntry: async (date, entry) => {
+      appended.push({ date, entry });
+    },
+  };
+
+  await processTriggers(
+    'watch.current',
+    { teamName: 'JL', startTime: 1, endTime: 2 },
+    {
+      'navigation.datetime': '2026-07-05T12:00:00.000Z',
+      'navigation.state': 'sailing',
+    },
+    log,
+    appHarness(),
+  );
+
+  assert.strictEqual(appended.length, 1);
+  assert.strictEqual(appended[0].entry.text, 'JL on watch');
+});
+
+test('processTriggers ignores object watch.current republished for the same team', async () => {
+  let appended = false;
+  const log = {
+    appendEntry: async () => {
+      appended = true;
+    },
+  };
+
+  await processTriggers(
+    'watch.current',
+    { teamName: 'JL', startTime: 30, endTime: 40 },
+    {
+      'navigation.datetime': '2026-07-05T12:00:00.000Z',
+      'navigation.state': 'sailing',
+      'watch.current': { teamName: 'JL', startTime: 10, endTime: 20 },
+    },
+    log,
+    appHarness(),
+  );
+
+  assert.strictEqual(appended, false);
+});


### PR DESCRIPTION
## Summary

Handle `watch.current` values published as objects when creating automatic watch log entries.

## Root cause

Some watch schedule publishers emit `watch.current` as an object containing fields such as `teamName`, rather than a plain string. The trigger interpolated the value directly, producing `[object Object] on watch`, and compared objects by identity, so repeated publications for the same watch could create repeated entries.

## Impact

Automatic watch entries use a readable watch label, and republished object values for the same watch do not create duplicate log entries.

## Validation

- Added coverage for label extraction from string and object `watch.current` values.
- Added coverage for creating `JL on watch` from an object value.
- Added coverage confirming repeated object values for the same team are ignored.
- Ran `npm test`.
