### PR TITLE
Add explicit datetime for manual entries

### DIFF
--- a/plugin/index.js
+++ b/plugin/index.js
@@ -1,9 +1,8 @@
 const CircularBuffer = require('circular-buffer');
 const timezones = require('timezones-list');
 const Log = require('./Log');
-const stateToEntry = require('./format');
-const applyBodyFields = require('./entryFields');
 const resolveAgo = require('./ago');
+const { newEntryFromBody } = require('./newEntry');
 const { processTriggers, processHourly } = require('./triggers');
 const { processNotification, sweepNotifications, buildConfig } = require('./notifications');
 const openAPI = require('../schema/openapi.json');
@@ -262,27 +261,38 @@ module.exports = (app) => {
     router.post('/logs', (req, res) => {
       res.contentType('application/json');
       let stats;
-      // Default to 0 (most recent sample) when `ago` is missing/invalid —
-      // otherwise buffer.get(undefined) throws and 500s the request.
-      const ago = resolveAgo(req.body.ago);
-      if (ago > buffer.size()) {
-        // We don't have history that far, sadly
-        res.sendStatus(404);
-        return;
-      }
-      if (buffer.size() > 0) {
-        stats = buffer.get(ago);
-      } else {
-        stats = {
-          ...state,
-        };
-      }
       let author = '';
       if (req.cookies && req.cookies.JAUTHENTICATION) {
         author = parseJwt(req.cookies.JAUTHENTICATION).id;
       }
-      const data = applyBodyFields(stateToEntry(stats, req.body.text, author), req.body);
-      if (req.body.observations && !Number.isNaN(Number(req.body.observations.seaState))) {
+      if (!req.body.datetime) {
+        // Default to 0 (most recent sample) when `ago` is missing/invalid —
+        // otherwise buffer.get(undefined) throws and 500s the request.
+        const ago = resolveAgo(req.body.ago);
+        if (ago > buffer.size()) {
+          // We don't have history that far, sadly
+          res.sendStatus(404);
+          return;
+        }
+        if (buffer.size() > 0) {
+          stats = buffer.get(ago);
+        } else {
+          stats = {
+            ...state,
+          };
+        }
+      }
+      let data;
+      try {
+        data = newEntryFromBody(req.body, stats, author);
+      } catch (e) {
+        handleError(e, res);
+        return;
+      }
+      const shouldSendSeaState = !req.body.datetime
+        && req.body.observations
+        && !Number.isNaN(Number(req.body.observations.seaState));
+      if (shouldSendSeaState) {
         sendDelta(
           app,
           plugin,

--- a/plugin/newEntry.js
+++ b/plugin/newEntry.js
@@ -1,0 +1,30 @@
+const stateToEntry = require('./format');
+const applyBodyFields = require('./entryFields');
+
+function explicitDatetime(value) {
+  if (!value) {
+    return null;
+  }
+  const datetime = new Date(value);
+  if (Number.isNaN(datetime.getTime())) {
+    throw new Error('Invalid datetime');
+  }
+  return datetime.toISOString();
+}
+
+function newEntryFromBody(body, stats, author = '') {
+  const datetime = explicitDatetime(body.datetime);
+  if (datetime) {
+    return applyBodyFields({
+      datetime,
+      text: body.text,
+      author,
+    }, body);
+  }
+  return applyBodyFields(stateToEntry(stats, body.text, author), body);
+}
+
+module.exports = {
+  explicitDatetime,
+  newEntryFromBody,
+};

--- a/schema/openapi.yaml
+++ b/schema/openapi.yaml
@@ -24,7 +24,7 @@ paths:
       tags:
       - entries
       summary: Create new log entry
-      description: Create a new log entry for either now or up to 15 minutes ago
+      description: Create a new log entry for either now, up to 15 minutes ago, or an explicit date-time
       requestBody:
         content:
           application/json:
@@ -166,6 +166,9 @@ components:
           type: integer
           minimum: 0
           maximum: 15
+        datetime:
+          type: string
+          format: date-time
         observations:
           $ref: '#/components/schemas/Observations'
         vhf:

--- a/src/components/AppPanel.jsx
+++ b/src/components/AppPanel.jsx
@@ -189,9 +189,11 @@ function AppPanel(props) {
           /> : null }
         { addEntry ? <EntryEditor
           entry={addEntry}
+          isNew={true}
           cancel={() => setAddEntry(null)}
           save={saveAddEntry}
           categories={categories}
+          displayTimeZone={timezone}
           /> : null }
         <Col className="bg-light border">
           <Nav tabs>

--- a/src/components/EntryEditor.jsx
+++ b/src/components/EntryEditor.jsx
@@ -18,12 +18,14 @@ import {
   AccordionHeader,
   AccordionItem,
 } from 'reactstrap';
+import { DateTime } from 'luxon';
 import { getSeaStates, getVisibility } from '../helpers/observations';
 
 function EntryEditor(props) {
   const [entry, updateEntry] = useState({
     ...props.entry,
   });
+  const isNew = props.isNew || !Number.isNaN(Number(entry.ago));
 
   const fixTypes = [
     'GPS',
@@ -33,6 +35,28 @@ function EntryEditor(props) {
     'Celestial',
     'DR',
   ];
+
+  function displayZone() {
+    return props.displayTimeZone || 'UTC';
+  }
+
+  function datetimeLocalNow() {
+    return DateTime.now().setZone(displayZone()).toFormat("yyyy-MM-dd'T'HH:mm");
+  }
+
+  function datetimeLocalToIso(value) {
+    const datetime = DateTime.fromFormat(value, "yyyy-MM-dd'T'HH:mm", {
+      zone: displayZone(),
+    });
+    return datetime.isValid ? datetime.toUTC().toISO() : value;
+  }
+
+  function whenValue() {
+    if (entry.datetime) {
+      return 'specific';
+    }
+    return Number.isNaN(Number(entry.ago)) ? '0' : entry.ago.toString();
+  }
 
   // Default: should observations be open?
   const [open, setOpen] = useState(entry.observations || !Number.isNaN(Number(entry.ago)) ? 'observations' : '');
@@ -87,6 +111,16 @@ function EntryEditor(props) {
         updated[name] = parseInt(value, 10);
         break;
       }
+      case 'when': {
+        if (value === 'specific') {
+          delete updated.ago;
+          updated.datetime = updated.datetime || datetimeLocalNow();
+        } else {
+          delete updated.datetime;
+          updated.ago = parseInt(value, 10);
+        }
+        break;
+      }
       default: {
         updated[name] = value;
       }
@@ -94,7 +128,15 @@ function EntryEditor(props) {
     updateEntry(updated);
   }
   function save() {
-    props.save(entry);
+    const savingEntry = {
+      ...entry,
+    };
+    if (savingEntry.datetime) {
+      savingEntry.datetime = datetimeLocalToIso(savingEntry.datetime);
+    }
+    delete savingEntry.when;
+    delete savingEntry.timeMode;
+    props.save(savingEntry);
   }
   function deleteEntry() {
     props.delete(entry);
@@ -110,15 +152,15 @@ function EntryEditor(props) {
   return (
     <Modal isOpen={true} toggle={props.cancel}>
       <ModalHeader toggle={props.cancel}>
-        { Number.isNaN(Number(entry.ago))
+        { !isNew
           && `Log entry ${entry.date.toLocaleString('en-GB', {
             timeZone: props.displayTimeZone,
           })} by ${entry.author || 'auto'}`}
-        { !Number.isNaN(Number(entry.ago))
+        { isNew
           && 'New entry'}
       </ModalHeader>
       <ModalBody>
-        { Number.isNaN(Number(entry.ago))
+        { !isNew
           && <Row>
           <Col className="text-end text-right">
             <Button color="danger" onClick={deleteEntry}>
@@ -141,22 +183,37 @@ function EntryEditor(props) {
               onChange={handleChange}
             />
           </FormGroup>
-          { !Number.isNaN(Number(entry.ago))
+          { isNew
             && <FormGroup>
-            <Label for="ago">
+            <Label for="when">
               This happened
             </Label>
             <Input
-              id="ago"
-              name="ago"
+              id="when"
+              name="when"
               type="select"
-              value={entry.ago}
+              value={whenValue()}
               onChange={handleChange}
             >
               {agoOptions.map((ago) => (
-              <option key={ago} value={ago}>{ago} minutes ago</option>
+              <option key={ago} value={ago}>{ago === 0 ? 'Now' : `${ago} minutes ago`}</option>
               ))}
+              <option value="specific">Specific time</option>
             </Input>
+          </FormGroup>
+          }
+          { isNew && whenValue() === 'specific'
+            && <FormGroup>
+            <Label for="datetime">
+              Date and time
+            </Label>
+            <Input
+              id="datetime"
+              name="datetime"
+              type="datetime-local"
+              value={entry.datetime || datetimeLocalNow()}
+              onChange={handleChange}
+            />
           </FormGroup>
           }
           <FormGroup>

--- a/test/newEntry.test.js
+++ b/test/newEntry.test.js
@@ -1,0 +1,61 @@
+const test = require('node:test');
+const assert = require('node:assert');
+const { explicitDatetime, newEntryFromBody } = require('../plugin/newEntry');
+
+test('explicitDatetime normalizes valid input to ISO', () => {
+  assert.strictEqual(
+    explicitDatetime('2026-07-07T18:45:00.000Z'),
+    '2026-07-07T18:45:00.000Z',
+  );
+});
+
+test('explicitDatetime rejects invalid input', () => {
+  assert.throws(() => explicitDatetime('not a date'), /Invalid datetime/);
+});
+
+test('newEntryFromBody uses state snapshot when datetime is absent', () => {
+  const entry = newEntryFromBody(
+    {
+      text: 'Sailing',
+      category: 'navigation',
+    },
+    {
+      'navigation.datetime': '2026-07-07T18:45:00.000Z',
+      'navigation.position': {
+        latitude: 48.7,
+        longitude: -4.4,
+      },
+      'environment.wind.speedOverGround': 5,
+    },
+    'admin',
+  );
+
+  assert.strictEqual(entry.datetime, '2026-07-07T18:45:00.000Z');
+  assert.deepStrictEqual(entry.position, { latitude: 48.7, longitude: -4.4 });
+  assert.deepStrictEqual(entry.wind, { speed: 9.7 });
+  assert.strictEqual(entry.author, 'admin');
+});
+
+test('newEntryFromBody with explicit datetime does not copy state-derived navigation data', () => {
+  const entry = newEntryFromBody(
+    {
+      datetime: '2026-07-07T18:45:00.000Z',
+      text: 'Forgotten note',
+      category: 'navigation',
+    },
+    {
+      'navigation.position': {
+        latitude: 48.7,
+        longitude: -4.4,
+      },
+      'environment.wind.speedOverGround': 5,
+    },
+    'admin',
+  );
+
+  assert.strictEqual(entry.datetime, '2026-07-07T18:45:00.000Z');
+  assert.strictEqual(entry.text, 'Forgotten note');
+  assert.strictEqual(entry.author, 'admin');
+  assert.strictEqual(entry.position, undefined);
+  assert.strictEqual(entry.wind, undefined);
+});


### PR DESCRIPTION
## Summary

Add support for creating a manual log entry at an explicit date and time.

The Add entry dialog keeps the historical `This happened` field and extends it with these choices:

- `Now`
- `5 minutes ago`
- `10 minutes ago`
- `15 minutes ago`
- `Specific time`

The date/time input is shown only when `Specific time` is selected.

## Behavior

When `datetime` is supplied to `POST /logs`, the server creates a minimal manual entry using the provided time, text, author, category, and any fields explicitly entered by the user. It does not look up Signal K history and does not copy the current/recent navigation snapshot.

This is intentional: it allows catching up a forgotten note after a navigation without inventing position, wind, speed, or other context from the wrong instant.

For `Now`, `5 minutes ago`, `10 minutes ago`, and `15 minutes ago`, the existing recent-buffer behavior is preserved.

The UI interprets the `datetime-local` value in the logbook display timezone, so a time entered as `10:00` is shown back as `10:00` in that configured timezone after saving.

## Validation

- Added unit coverage for explicit datetime normalization and invalid datetime rejection.
- Added coverage confirming explicit datetime entries do not copy state-derived position or wind.
- Added coverage confirming the existing snapshot behavior is preserved when `datetime` is absent.
- Ran `npm test`.

Fixes #78 
