### PR TITLE
Make the log map use configured charts, fall back to a default (#76)

### DIFF
--- a/src/components/Map.jsx
+++ b/src/components/Map.jsx
@@ -2,6 +2,7 @@ import React, { useState, useEffect, useRef } from 'react';
 import { Map as PigeonMap, GeoJson, Marker } from 'pigeon-maps';
 import { Point } from 'where';
 import { viewport } from '@mapbox/geo-viewport';
+import { chartLayersWithFallback, tileProvider, DEFAULT_LAYER } from '../helpers/charts';
 
 function calculateBounds(points) {
   if (!points.length) {
@@ -30,6 +31,10 @@ function Map(props) {
   })));
   const [bbox, setBbox] = useState([640, 480]);
   const mapContainer = useRef(null);
+  // Tile layers come from SignalK's configured charts; fall back to a default
+  // until the fetch resolves (and if none are configured). See helpers/charts.
+  const [layers, setLayers] = useState([DEFAULT_LAYER]);
+  const [activeLayer, setActiveLayer] = useState(0);
   useEffect(() => {
     if (!mapContainer.current) {
       return;
@@ -37,6 +42,17 @@ function Map(props) {
     const rect = mapContainer.current.getBoundingClientRect();
     setBbox([rect.width, rect.height]);
   }, []);
+  useEffect(() => {
+    fetch('/signalk/v1/api/resources/charts')
+      .then((res) => (res.ok ? res.json() : null))
+      .then((resource) => {
+        const available = chartLayersWithFallback(resource);
+        setLayers(available);
+        setActiveLayer((current) => (current < available.length ? current : 0));
+      })
+      .catch(() => {});
+  }, []);
+  const layer = layers[activeLayer] || DEFAULT_LAYER;
   const viewportResult = viewport(calculateBounds(points), bbox);
   const centerAndZoom = {
     center: [viewportResult.center[1], viewportResult.center[0]],
@@ -119,10 +135,43 @@ function Map(props) {
   };
   return (
   <div ref={mapContainer} style={{
+    position: 'relative',
     width: '80vw',
     height: '80vh',
   }}>
+    {layers.length > 1 ? (
+      <div style={{
+        position: 'absolute',
+        zIndex: 400,
+        margin: '8px',
+        background: 'rgba(255,255,255,0.85)',
+        borderRadius: '4px',
+        padding: '2px',
+      }}>
+        {layers.map((l, idx) => (
+          <button
+            key={l.identifier}
+            type="button"
+            onClick={() => setActiveLayer(idx)}
+            style={{
+              border: 'none',
+              margin: '1px',
+              padding: '2px 6px',
+              cursor: 'pointer',
+              borderRadius: '3px',
+              background: idx === activeLayer ? '#009bdb' : 'transparent',
+              color: idx === activeLayer ? '#fff' : '#333',
+            }}
+          >
+            {l.name}
+          </button>
+        ))}
+      </div>
+    ) : null}
     <PigeonMap
+      provider={tileProvider(layer.url)}
+      minZoom={layer.minZoom}
+      maxZoom={layer.maxZoom}
       center={centerAndZoom.center}
       zoom={centerAndZoom.zoom}
     >

--- a/src/helpers/charts.js
+++ b/src/helpers/charts.js
@@ -1,0 +1,64 @@
+// Tile-layer helpers for the log Map. SignalK exposes configured charts at
+// `resources/charts`; we turn the tile charts into pigeon-maps providers so the
+// map shows whatever the user already set up (offline MBTiles, ENCs, a
+// referer-tolerant proxy…) instead of hardcoding OSM's public tiles, which now
+// 403 for referer-less self-hosted setups (issue #76).
+
+// Backward-compatible default when no tile charts are configured.
+const DEFAULT_LAYER = {
+  identifier: 'osm',
+  name: 'OpenStreetMap',
+  url: 'https://tile.openstreetmap.org/{z}/{x}/{y}.png',
+  minZoom: 0,
+  maxZoom: 19,
+};
+
+// Normalize a SignalK `resources/charts` object into the tile layers we can
+// render. Charts without a `tilemapUrl` (WMS, S-57, plain PDFs…) are dropped.
+function parseChartLayers(resource) {
+  if (!resource || typeof resource !== 'object') {
+    return [];
+  }
+  return Object.keys(resource)
+    .map((key) => {
+      const chart = resource[key];
+      if (!chart || !chart.tilemapUrl) {
+        return null;
+      }
+      return {
+        identifier: chart.identifier || key,
+        name: chart.name || chart.identifier || key,
+        url: chart.tilemapUrl,
+        minZoom: typeof chart.minzoom === 'number' ? chart.minzoom : 0,
+        maxZoom: typeof chart.maxzoom === 'number' ? chart.maxzoom : 19,
+      };
+    })
+    .filter((layer) => layer !== null)
+    .sort((a, b) => a.name.localeCompare(b.name));
+}
+
+// Configured tile layers, or a single sane default when none are set up.
+function chartLayersWithFallback(resource) {
+  const layers = parseChartLayers(resource);
+  return layers.length ? layers : [DEFAULT_LAYER];
+}
+
+// Turn a `{z}/{x}/{y}` (and optional `{s}` subdomain) template into a
+// pigeon-maps provider: (x, y, z, dpr) => url.
+function tileProvider(url) {
+  return (x, y, z) => {
+    const s = 'abc'[(x + y) % 3];
+    return url
+      .replace('{s}', s)
+      .replace('{z}', z)
+      .replace('{x}', x)
+      .replace('{y}', y);
+  };
+}
+
+module.exports = {
+  DEFAULT_LAYER,
+  parseChartLayers,
+  chartLayersWithFallback,
+  tileProvider,
+};

--- a/test/charts.test.js
+++ b/test/charts.test.js
@@ -1,0 +1,82 @@
+const test = require('node:test');
+const assert = require('node:assert');
+const charts = require('../src/helpers/charts');
+
+// A SignalK `resources/charts` response is an object keyed by chart identifier.
+// Tile charts carry a `tilemapUrl` template; other chart types (WMS, S-57…)
+// do not and can't be shown as Leaflet/pigeon tiles.
+const sampleResource = {
+  osm: {
+    identifier: 'osm',
+    name: 'OpenStreetMap',
+    tilemapUrl: 'https://tile.openstreetmap.org/{z}/{x}/{y}.png',
+    type: 'tilelayer',
+    minzoom: 0,
+    maxzoom: 19,
+  },
+  noaa: {
+    identifier: 'noaa',
+    name: 'NOAA ENC',
+    tilemapUrl: 'http://localhost:8080/noaa/{z}/{x}/{y}.png',
+    type: 'tilelayer',
+    minzoom: 4,
+    maxzoom: 16,
+  },
+  wms: {
+    identifier: 'wms',
+    name: 'Some WMS',
+    type: 'WMS',
+    chartUrl: 'http://example.com/wms',
+  },
+};
+
+test('parseChartLayers returns [] for missing or empty resources', () => {
+  assert.deepStrictEqual(charts.parseChartLayers(undefined), []);
+  assert.deepStrictEqual(charts.parseChartLayers(null), []);
+  assert.deepStrictEqual(charts.parseChartLayers({}), []);
+});
+
+test('parseChartLayers keeps only tile charts and maps their fields', () => {
+  const layers = charts.parseChartLayers(sampleResource);
+  assert.strictEqual(layers.length, 2);
+  const osm = layers.find((l) => l.identifier === 'osm');
+  assert.deepStrictEqual(osm, {
+    identifier: 'osm',
+    name: 'OpenStreetMap',
+    url: 'https://tile.openstreetmap.org/{z}/{x}/{y}.png',
+    minZoom: 0,
+    maxZoom: 19,
+  });
+  // The WMS chart has no tilemapUrl and must be dropped
+  assert.ok(!layers.some((l) => l.identifier === 'wms'));
+});
+
+test('parseChartLayers sorts layers by name for a stable switcher', () => {
+  const names = charts.parseChartLayers(sampleResource).map((l) => l.name);
+  assert.deepStrictEqual(names, ['NOAA ENC', 'OpenStreetMap']);
+});
+
+test('chartLayersWithFallback returns configured layers untouched when present', () => {
+  const layers = charts.chartLayersWithFallback(sampleResource);
+  assert.strictEqual(layers.length, 2);
+  assert.ok(!layers.some((l) => l.identifier === charts.DEFAULT_LAYER.identifier
+    && l.url === charts.DEFAULT_LAYER.url && layers.length > 2));
+});
+
+test('chartLayersWithFallback falls back to a single default layer when empty', () => {
+  assert.deepStrictEqual(charts.chartLayersWithFallback({}), [charts.DEFAULT_LAYER]);
+  assert.deepStrictEqual(charts.chartLayersWithFallback(undefined), [charts.DEFAULT_LAYER]);
+});
+
+test('tileProvider substitutes {z}/{x}/{y} into the template', () => {
+  const provider = charts.tileProvider('https://tile.openstreetmap.org/{z}/{x}/{y}.png');
+  assert.strictEqual(provider(5, 3, 7), 'https://tile.openstreetmap.org/7/5/3.png');
+});
+
+test('tileProvider rotates {s} subdomains deterministically', () => {
+  const provider = charts.tileProvider('https://{s}.example.com/{z}/{x}/{y}.png');
+  // subdomain chosen from x+y so the same tile always hits the same host
+  assert.strictEqual(provider(0, 0, 1), 'https://a.example.com/1/0/0.png');
+  assert.strictEqual(provider(1, 0, 1), 'https://b.example.com/1/1/0.png');
+  assert.strictEqual(provider(1, 1, 1), 'https://c.example.com/1/1/1.png');
+});


### PR DESCRIPTION
Fixes #76. The map's tiles came from pigeon-maps' hardcoded OSM default, which 403s on referer-less self-hosted setups.

Per the thread, this reads whatever's in `resources/charts` and uses that — offline MBTiles, ENCs, a referer-tolerant proxy, whatever you've already configured — with a layer switcher when there's more than one. Falls back to the OSM default when the registry's empty, so nothing changes for people who haven't set up charts.

Tile-parsing logic is extracted to `src/helpers/charts.js` with unit tests.

Heads up: the empty-registry fallback is still OSM, so folks with no charts plugin will still hit the referer 403 — that root cause is signalk-server's `no-referrer` policy. Happy to follow up on a saner default there if you want.