### PR TITLE
Add entry origin: manual | auto | agent

### DIFF
--- a/plugin/Log.js
+++ b/plugin/Log.js
@@ -50,6 +50,7 @@ class Log {
           return data.map((entry) => ({
             ...entry,
             category: entry.category || 'navigation',
+            origin: entry.origin || (entry.author ? 'manual' : 'auto'),
             datetime: new Date(entry.datetime),
           }));
         }));

--- a/plugin/entryFields.js
+++ b/plugin/entryFields.js
@@ -28,5 +28,13 @@ module.exports = function applyBodyFields(data, body) {
       ...body.position,
     };
   }
+  if (typeof body.author === 'string' && body.author.length >= 1) {
+    // Delegation: an authenticated client (voice assistant, crew app) writes
+    // the line on behalf of the person who authored it.
+    entry.author = body.author;
+  }
+  if (['manual', 'auto', 'agent'].includes(body.origin)) {
+    entry.origin = body.origin;
+  }
   return entry;
 };

--- a/plugin/format.js
+++ b/plugin/format.js
@@ -6,11 +6,12 @@ function ms2kt(ms) {
   return parseFloat((ms * 1.94384).toFixed(1));
 }
 
-module.exports = function stateToEntry(state, text, author = '') {
+module.exports = function stateToEntry(state, text, author = '', origin = 'manual') {
   const data = {
     datetime: state['navigation.datetime'] || new Date().toISOString(),
     text,
     author,
+    origin,
   };
   if (state['navigation.position']) {
     data.position = {

--- a/plugin/newEntry.js
+++ b/plugin/newEntry.js
@@ -19,6 +19,7 @@ function newEntryFromBody(body, stats, author = '') {
       datetime,
       text: body.text,
       author,
+      origin: 'manual',
     }, body);
   }
   return applyBodyFields(stateToEntry(stats, body.text, author), body);

--- a/plugin/notifications.js
+++ b/plugin/notifications.js
@@ -76,7 +76,7 @@ function buildConfig(options = {}) {
 }
 
 function appendEntry(log, app, state, text, category, datetimeOverride) {
-  const data = stateToEntry(state, text);
+  const data = stateToEntry(state, text, '', 'auto');
   data.category = category;
   if (datetimeOverride != null) {
     data.datetime = new Date(datetimeOverride).toISOString();

--- a/plugin/triggers.js
+++ b/plugin/triggers.js
@@ -43,7 +43,7 @@ function sailsString(state, app) {
 
 exports.processTriggers = function processTriggers(path, value, oldState, log, app) {
   function appendLog(text, additionalData = {}) {
-    const data = stateToEntry(oldState, text);
+    const data = stateToEntry(oldState, text, '', 'auto');
     Object.keys(additionalData).forEach((key) => {
       data[key] = additionalData[key];
     });
@@ -222,7 +222,7 @@ exports.processHourly = function processHourly(oldState, log, app, minutesAfter 
   if (oldState['navigation.state'] !== 'sailing' && oldState['navigation.state'] !== 'motoring') {
     return Promise.resolve();
   }
-  const data = stateToEntry(oldState, '');
+  const data = stateToEntry(oldState, '', '', 'auto');
 
   const dateString = data.datetime.substr(0, 10);
 

--- a/schema/openapi.yaml
+++ b/schema/openapi.yaml
@@ -305,6 +305,14 @@ components:
         author:
           type: string
           example: auto
+        origin:
+          type: string
+          enum:
+          - manual
+          - auto
+          - agent
+          default: manual
+          example: auto
         category:
           type: string
           enum:

--- a/schema/openapi.yaml
+++ b/schema/openapi.yaml
@@ -176,6 +176,15 @@ components:
           maxLength: 2
           minLength: 1
           example: '70'
+        author:
+          type: string
+          example: Bryan
+        origin:
+          type: string
+          enum:
+          - manual
+          - auto
+          - agent
     Entry:
       type: object
       additionalProperties: false

--- a/src/components/EntryViewer.jsx
+++ b/src/components/EntryViewer.jsx
@@ -7,6 +7,7 @@ import {
   Button,
 } from 'reactstrap';
 import EntryDetails from './EntryDetails.jsx';
+import OriginBadge from './OriginBadge.jsx';
 
 function EntryViewer(props) {
   const { entry } = props;
@@ -16,6 +17,7 @@ function EntryViewer(props) {
         Log entry {entry.date.toLocaleString('en-GB', {
           timeZone: props.displayTimeZone,
         })} by {entry.author || 'auto'}
+        <OriginBadge origin={entry.origin} />
       </ModalHeader>
       <ModalBody>
         <EntryDetails entry={entry} />

--- a/src/components/Logbook.jsx
+++ b/src/components/Logbook.jsx
@@ -6,6 +6,7 @@ import {
 import { Point } from 'where';
 import { DateTime } from 'luxon';
 import styles from './styles.module.css';
+import OriginBadge from './OriginBadge.jsx';
 
 function getWeather(entry) {
   const weather = [];
@@ -109,7 +110,7 @@ function Logbook(props) {
                 ? Object.entries(entry.engine.engines).map(([name, e]) => `${name}: ${e.hours}h`).join(', ')
                 : !Number.isNaN(Number(entry.engine.hours)) ? `${entry.engine.hours}h` : ''
             )}</td>
-            <td>{entry.author || 'auto'}</td>
+            <td>{entry.author || 'auto'}<OriginBadge origin={entry.origin} /></td>
             <td>{entry.text}</td>
           </tr>
         ))}

--- a/src/components/OriginBadge.jsx
+++ b/src/components/OriginBadge.jsx
@@ -1,0 +1,30 @@
+import React from 'react';
+
+// EU "AI" label icon for AI-generated content, inlined so it survives
+// module federation (file-loader paths break under the admin UI host).
+// Source: https://digital-strategy.ec.europa.eu/en/policies/eu-icons-labelling-ai-generated-content
+// (free to use, no attribution required)
+function OriginBadge(props) {
+  if (props.origin !== 'agent') {
+    return null;
+  }
+  return (
+    <svg
+      viewBox="89 100 366 366"
+      width="1em"
+      height="1em"
+      role="img"
+      aria-label="AI-generated entry"
+      style={{ verticalAlign: '-0.125em', marginLeft: '0.25em' }}
+    >
+      <title>AI-generated entry</title>
+      <path fillRule="evenodd" fill="currentColor" d="M272.03,100.72c100.92,0,182.74,81.82,182.74,182.75s-81.82,182.74-182.74,182.74-182.75-81.82-182.75-182.74,81.82-182.75,182.75-182.75" />
+      <g fill="#fff">
+        <path d="M170.79,353.74c-1.08,0-2.05-.43-2.92-1.31-.88-.87-1.31-1.84-1.31-2.92,0-.67.07-1.27.2-1.81l47.34-129.32c.4-1.48,1.24-2.79,2.52-3.93,1.27-1.14,3.05-1.71,5.34-1.71h29.81c2.28,0,4.06.57,5.34,1.71,1.27,1.14,2.11,2.45,2.52,3.93l47.14,129.32c.27.54.4,1.14.4,1.81,0,1.08-.44,2.05-1.31,2.92s-1.91,1.31-3.12,1.31h-24.78c-2.01,0-3.52-.5-4.53-1.51-1.01-1.01-1.65-1.91-1.91-2.72l-7.86-20.55h-53.78l-7.65,20.55c-.27.81-.88,1.71-1.81,2.72-.94,1.01-2.55,1.51-4.83,1.51h-24.78ZM218.13,299.96h37.47l-18.93-53.18-18.53,53.18Z" />
+        <path d="M328.11,353.74c-1.48,0-2.69-.47-3.63-1.41-.94-.94-1.41-2.15-1.41-3.63v-130.93c0-1.48.47-2.68,1.41-3.63s2.15-1.41,3.63-1.41h26.99c1.48,0,2.68.47,3.63,1.41.94.94,1.41,2.15,1.41,3.63v130.93c0,1.48-.47,2.69-1.41,3.63-.94.94-2.15,1.41-3.63,1.41h-26.99Z" />
+      </g>
+    </svg>
+  );
+}
+
+export default OriginBadge;

--- a/src/components/Timeline.jsx
+++ b/src/components/Timeline.jsx
@@ -10,6 +10,7 @@ import {
 } from 'reactstrap';
 import { Point } from 'where';
 import EntryDetails from './EntryDetails.jsx';
+import OriginBadge from './OriginBadge.jsx';
 
 function Timeline(props) {
   const entries = props.entries.map((entry) => ({
@@ -27,6 +28,7 @@ function Timeline(props) {
             <Row>
               <Col xs="3">
                 {entry.author || 'auto'}
+                <OriginBadge origin={entry.origin} />
               </Col>
               <Col className="text-end text-right">
                 {entry.date.toLocaleString('en-GB', {

--- a/test/Log.test.js
+++ b/test/Log.test.js
@@ -95,6 +95,29 @@ test('appendEntry creates a new day file when none exists', async () => {
   }
 });
 
+test('getDate assigns origin to legacy entries at read time', async () => {
+  const dir = await mkdtemp(join(tmpdir(), 'logbook-test-'));
+  try {
+    const date = '2026-06-11';
+    const stored = [
+      { datetime: '2026-06-11T08:00:00.000Z', text: 'Hourly entry' },
+      { datetime: '2026-06-11T09:00:00.000Z', text: 'Sail change', author: 'bryan' },
+      {
+        datetime: '2026-06-11T10:00:00.000Z', text: 'Drill logged', author: 'poseidon', origin: 'agent',
+      },
+    ];
+    await writeFile(join(dir, `${date}.yml`), stringify(stored), 'utf-8');
+
+    const log = new Log(dir);
+    const entries = await log.getDate(date);
+    assert.strictEqual(entries[0].origin, 'auto', 'authorless legacy entries read as auto');
+    assert.strictEqual(entries[1].origin, 'manual', 'authored legacy entries read as manual');
+    assert.strictEqual(entries[2].origin, 'agent', 'stored origin is preserved');
+  } finally {
+    await rm(dir, { recursive: true, force: true });
+  }
+});
+
 test('writeEntry creates a new day file when none exists', async () => {
   const dir = await mkdtemp(join(tmpdir(), 'logbook-test-'));
   try {

--- a/test/entryFields.test.js
+++ b/test/entryFields.test.js
@@ -40,3 +40,19 @@ test('state-derived fields pass through untouched', () => {
   assert.strictEqual(entry.heading, 190);
   assert.strictEqual(entry.vhf, '16'); // auto-captured channel kept when body has none
 });
+
+test('body author overrides the cookie-derived one (delegation)', () => {
+  assert.strictEqual(applyBodyFields({ author: 'token-id' }, { author: 'Bryan' }).author, 'Bryan');
+  assert.strictEqual(applyBodyFields({ author: 'token-id' }, {}).author, 'token-id');
+});
+
+test('non-string or empty body author is ignored', () => {
+  assert.strictEqual(applyBodyFields({ author: 'a' }, { author: '' }).author, 'a');
+  assert.strictEqual(applyBodyFields({ author: 'a' }, { author: 42 }).author, 'a');
+});
+
+test('body origin is accepted when valid, ignored otherwise', () => {
+  assert.strictEqual(applyBodyFields({ origin: 'manual' }, { origin: 'agent' }).origin, 'agent');
+  assert.strictEqual(applyBodyFields({ origin: 'manual' }, { origin: 'bogus' }).origin, 'manual');
+  assert.strictEqual(applyBodyFields({ origin: 'manual' }, {}).origin, 'manual');
+});

--- a/test/entryFields.test.js
+++ b/test/entryFields.test.js
@@ -47,6 +47,10 @@ test('body author overrides the cookie-derived one (delegation)', () => {
 });
 
 test('non-string or empty body author is ignored', () => {
+  // entry with NO pre-existing author: bad body.author must not produce one
+  assert.strictEqual(applyBodyFields({}, { author: '' }).author, undefined);
+  assert.strictEqual(applyBodyFields({}, { author: 42 }).author, undefined);
+  // pre-existing author preserved when body.author is bad
   assert.strictEqual(applyBodyFields({ author: 'a' }, { author: '' }).author, 'a');
   assert.strictEqual(applyBodyFields({ author: 'a' }, { author: 42 }).author, 'a');
 });
@@ -55,4 +59,5 @@ test('body origin is accepted when valid, ignored otherwise', () => {
   assert.strictEqual(applyBodyFields({ origin: 'manual' }, { origin: 'agent' }).origin, 'agent');
   assert.strictEqual(applyBodyFields({ origin: 'manual' }, { origin: 'bogus' }).origin, 'manual');
   assert.strictEqual(applyBodyFields({ origin: 'manual' }, {}).origin, 'manual');
+  assert.strictEqual(applyBodyFields({}, { origin: 'bogus' }).origin, undefined);
 });

--- a/test/format.test.js
+++ b/test/format.test.js
@@ -46,3 +46,9 @@ test('pre-existing entry with only engine.hours loads without error', () => {
   assert.strictEqual(oldEntry.engine.hours, 10.5);
   assert.strictEqual(oldEntry.engine.engines, undefined);
 });
+
+test('stateToEntry stamps origin manual by default and accepts an override', () => {
+  assert.strictEqual(stateToEntry({}, 'hello').origin, 'manual');
+  assert.strictEqual(stateToEntry({}, 'hello', '', 'auto').origin, 'auto');
+  assert.strictEqual(stateToEntry({}, 'hello', 'poseidon', 'agent').origin, 'agent');
+});

--- a/test/newEntry.test.js
+++ b/test/newEntry.test.js
@@ -59,3 +59,30 @@ test('newEntryFromBody with explicit datetime does not copy state-derived naviga
   assert.strictEqual(entry.position, undefined);
   assert.strictEqual(entry.wind, undefined);
 });
+
+test('newEntryFromBody with explicit datetime defaults origin to manual', () => {
+  const entry = newEntryFromBody(
+    {
+      datetime: '2026-07-07T18:45:00.000Z',
+      text: 'Explicit time entry',
+    },
+    {},
+    'admin',
+  );
+
+  assert.strictEqual(entry.origin, 'manual');
+});
+
+test('newEntryFromBody with explicit datetime allows body origin to override', () => {
+  const entry = newEntryFromBody(
+    {
+      datetime: '2026-07-07T18:45:00.000Z',
+      text: 'Agent entry',
+      origin: 'agent',
+    },
+    {},
+    'admin',
+  );
+
+  assert.strictEqual(entry.origin, 'agent');
+});

--- a/test/notifications.test.js
+++ b/test/notifications.test.js
@@ -277,3 +277,22 @@ test('logNotificationClears:false closes episodes without a clear entry', async 
   assert.strictEqual(entries.length, 1);
   assert.strictEqual(episodes.size, 0);
 });
+
+test('notification entries are stamped origin auto', async () => {
+  let captured;
+  const log = { appendEntry: async (date, data) => { captured = data; } };
+  const app = { setPluginStatus: () => {} };
+  const episodes = new Map();
+  await n.processNotification(
+    'notifications.navigation.restrictedArea.x',
+    { state: 'warn', message: 'Test warning' },
+    {},
+    episodes,
+    log,
+    app,
+    n.buildConfig({}),
+    Date.now(),
+  );
+  assert.strictEqual(captured.origin, 'auto');
+  assert.strictEqual(captured.author, '');
+});


### PR DESCRIPTION
Hey Henri 👋

Follow-on from the crewNames work: now that entries snapshot who's aboard, I wanted the log to also record *how* each line got written. In a paper logbook the officer on watch signs the page even when the instruments took the reading — `author` stays "who is responsible", and this PR adds a small `origin` field for "did the pen or the instruments write the line".

What's in here:

- **`origin` on Entry** — optional enum `manual | auto | agent`, default `manual`. Absent on existing archives = legacy; no migration needed.
- **Unattended writers stamp `auto`** — notification entries, trigger entries (autopilot/crew/sail changes), and the hourly underway log.
- **POST /logs accepts `author` and `origin`** — so an authenticated client (a voice assistant, a crew app) can write a line on someone's behalf and sign it for them. PUT already honors a body-supplied author; this just makes POST consistent. Invalid origin values are ignored rather than erroring.
- Schema updates for both (Entry + NewEntry) and tests for all of it.

The `agent` value is for AI/assistant-composed entries — my setup logs drills and voice-dictated notes through the REST API, and I wanted those distinguishable from both human-typed lines and the plugin's own automatic entries when reading a day back.

Happy to also add a small origin badge in the web UI as a follow-up if you'd take it.
