### PR TITLE
Snapshot communication.skipperName into log entries

### DIFF
--- a/plugin/format.js
+++ b/plugin/format.js
@@ -105,5 +105,8 @@ module.exports = function stateToEntry(state, text, author = '', origin = 'manua
   if (state['communication.crewNames']) {
     data.crewNames = state['communication.crewNames'];
   }
+  if (state['communication.skipperName']) {
+    data.skipperName = state['communication.skipperName'];
+  }
   return data;
 };

--- a/plugin/index.js
+++ b/plugin/index.js
@@ -81,6 +81,7 @@ module.exports = (app) => {
     'sails.inventory.*',
     'steering.autopilot.state',
     'communication.crewNames',
+    'communication.skipperName',
     'communication.vhf.channel',
     'notifications.*',
     'watch.current',

--- a/plugin/triggers.js
+++ b/plugin/triggers.js
@@ -146,6 +146,12 @@ exports.processTriggers = function processTriggers(path, value, oldState, log, a
       }
       break;
     }
+    case 'communication.skipperName': {
+      if (!oldState[path] || !value || oldState[path] === value) {
+        return Promise.resolve();
+      }
+      return appendLog(`${value} took over as skipper`);
+    }
     case 'watch.current': {
       const nameValue = (value && value.teamName) ? value.teamName : null;
       if (oldState[path] === nameValue

--- a/schema/openapi.yaml
+++ b/schema/openapi.yaml
@@ -305,6 +305,9 @@ components:
           type: array
           items:
             type: string
+        skipperName:
+          type: string
+          example: Alice
         end:
           type: boolean
           default: false

--- a/test/format.test.js
+++ b/test/format.test.js
@@ -52,3 +52,17 @@ test('stateToEntry stamps origin manual by default and accepts an override', () 
   assert.strictEqual(stateToEntry({}, 'hello', '', 'auto').origin, 'auto');
   assert.strictEqual(stateToEntry({}, 'hello', 'poseidon', 'agent').origin, 'agent');
 });
+
+test('skipperName is snapshotted into the entry', () => {
+  const state = { 'communication.skipperName': 'Alice' };
+
+  const entry = stateToEntry(state, 'Test entry');
+
+  assert.strictEqual(entry.skipperName, 'Alice');
+});
+
+test('entry has no skipperName key when state lacks one', () => {
+  const entry = stateToEntry({}, 'Test entry');
+
+  assert.strictEqual('skipperName' in entry, false);
+});

--- a/test/triggers-skipper.test.js
+++ b/test/triggers-skipper.test.js
@@ -1,0 +1,97 @@
+const test = require('node:test');
+const assert = require('node:assert');
+const { processTriggers } = require('../plugin/triggers');
+
+function appHarness() {
+  return {
+    setPluginStatus: () => {},
+  };
+}
+
+test('processTriggers logs a skipper change', async () => {
+  const appended = [];
+  const log = {
+    appendEntry: async (date, entry) => {
+      appended.push({ date, entry });
+    },
+  };
+
+  await processTriggers(
+    'communication.skipperName',
+    'Bob',
+    {
+      'navigation.datetime': '2026-07-05T12:00:00.000Z',
+      'communication.skipperName': 'Alice',
+    },
+    log,
+    appHarness(),
+  );
+
+  assert.strictEqual(appended.length, 1);
+  assert.strictEqual(appended[0].entry.text, 'Bob took over as skipper');
+});
+
+test('processTriggers ignores unchanged skipper', async () => {
+  let appended = false;
+  const log = {
+    appendEntry: async () => {
+      appended = true;
+    },
+  };
+
+  await processTriggers(
+    'communication.skipperName',
+    'Alice',
+    {
+      'navigation.datetime': '2026-07-05T12:00:00.000Z',
+      'communication.skipperName': 'Alice',
+    },
+    log,
+    appHarness(),
+  );
+
+  assert.strictEqual(appended, false);
+});
+
+test('processTriggers ignores initial skipper value', async () => {
+  let appended = false;
+  const log = {
+    appendEntry: async () => {
+      appended = true;
+    },
+  };
+
+  await processTriggers(
+    'communication.skipperName',
+    'Alice',
+    {
+      'navigation.datetime': '2026-07-05T12:00:00.000Z',
+    },
+    log,
+    appHarness(),
+  );
+
+  assert.strictEqual(appended, false);
+});
+
+test('processTriggers ignores skipper being cleared', async () => {
+  let appended = false;
+  const log = {
+    appendEntry: async () => {
+      appended = true;
+    },
+  };
+
+  await processTriggers(
+    'communication.skipperName',
+    null,
+    {
+      'navigation.datetime': '2026-07-05T12:00:00.000Z',
+      'communication.skipperName': 'Alice',
+    },
+    log,
+    appHarness(),
+  );
+
+  assert.strictEqual(appended, false);
+});


### PR DESCRIPTION
Follows up #89 — here's the shape of it.

- Subscribes to `communication.skipperName` (already in the Signal K spec, as you pointed out)
- Snapshots it into entries next to `crewNames`, so every entry records who was skipper at the time
- Logs an automatic entry on handoff ("Bob took over as skipper") — initial value and clearing are ignored, matching the crewNames trigger behavior

With `crewNames` + `skipperName` on every entry you can derive skipper-vs-crew per day for sea-service records, and your Lille Ø rotation gets recorded for free once you update `skipperName` on handoff.

One convention worth stating: the two paths stay fully independent — nothing validates that the skipper appears in `crewNames` (either path could come from another source, in either order). The intended convention is `crewNames` = everyone aboard including the skipper, and consumers deriving "who was aboard" should union the two fields to be safe. Didn't feel like something the logbook should enforce.

One deliberate omission: I didn't add a way to *set* skipperName from the logbook (config option / PUT handler / crew editor) the way crewNames has, since any source can publish the spec path. Happy to add that as a follow-up if you'd rather the crew editor own it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01R6J9D9TvLRqPnpSm7REy5W