### PR TITLE
Guard hourly buffer read to avoid RangeError wedging the interval (fixes #95)

### DIFF
--- a/plugin/index.js
+++ b/plugin/index.js
@@ -182,7 +182,7 @@ module.exports = (app) => {
       }
       // How many minutes within the hour do we consider be the "hour entry"?
       const hourlyWindow = 1;
-      if (new Date(state.datetime).getMinutes() === hourlyWindow) {
+      if (new Date(state.datetime).getMinutes() === hourlyWindow && buffer.size() > hourlyWindow) {
         // Store hourly log entry
         const hourlyState = buffer.get(hourlyWindow);
         processHourly(hourlyState, log, app, hourlyWindow)


### PR DESCRIPTION
Fixes #95.

The hourly branch in the 60s interval calls `buffer.get(hourlyWindow)`
unconditionally whenever the current minute equals `hourlyWindow`. When the ring
buffer holds fewer than `hourlyWindow + 1` samples — the case for the first
couple of minutes after every start/restart — `CircularBuffer.get(1)` throws
`RangeError: Index past end of buffer: 1`.

Because that throw happens **before** `buffer.enq(state)`, the
`sweepNotifications(...)` call and the `state.datetime` reset, the interval can
wedge: the buffer never enqueues (so it never grows), `state.datetime` is never
reset (so the `getMinutes() === hourlyWindow` guard keeps matching), and the
callback throws every 60 s while notification auto-logging effectively stops.

This guards the hourly read with `buffer.size() > hourlyWindow` so it only runs
once enough samples are buffered. `buffer.enq`, `sweepNotifications` and the
`state.datetime` reset now always run regardless.
